### PR TITLE
Work around missing np.float128 and np.complex256

### DIFF
--- a/src/xradio/image/_util/_zarr/common.py
+++ b/src/xradio/image/_util/_zarr/common.py
@@ -3,9 +3,7 @@ import numpy as np
 
 _np_types = {
     "complex128": np.complex128,
-    "complex256": np.complex256,
     "complex64": np.complex64,
-    "float128": np.float128,
     "float64": np.float64,
     "float16": np.float16,
     "float32": np.float32,
@@ -15,5 +13,9 @@ _np_types = {
     "int64": np.int64,
 }
 
+if hasattr(np, "complex256"):
+    _np_types["complex256"] = np.complex256
+if hasattr(np, "float128"):
+    _np_types["float128"] = np.float128
 
 _top_level_sub_xds = "_attrs_xds"

--- a/src/xradio/image/_util/_zarr/common.py
+++ b/src/xradio/image/_util/_zarr/common.py
@@ -13,9 +13,4 @@ _np_types = {
     "int64": np.int64,
 }
 
-if hasattr(np, "complex256"):
-    _np_types["complex256"] = np.complex256
-if hasattr(np, "float128"):
-    _np_types["float128"] = np.float128
-
 _top_level_sub_xds = "_attrs_xds"


### PR DESCRIPTION
Apparently Mac M1 does not have these types (probably because it's a 64-bit system).

For reference I'm running on mac M1, python 3.12, numpy 1.26.3.