### PR TITLE
Performance Improvements of Unique Baselines and Baseline Indices

### DIFF
--- a/src/xradio/vis/_vis_utils/_ms/_tables/read.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read.py
@@ -12,7 +12,7 @@ import astropy.units
 from casacore import tables
 
 from .table_query import open_query, open_table_ro
-
+from xradio.vis._vis_utils._ms.optimised_functions import unique
 
 CASACORE_TO_PD_TIME_CORRECTION = 3506716800.0
 SECS_IN_DAY = 86400
@@ -442,10 +442,8 @@ def read_generic_cols(
                 )
         except Exception:
             # sometimes the cols are variable, so we need to standardize to the largest sizes
-            
-            # TODO
-            # swap np.unique(arr) for np.sort(pd.unique(arr))
-            if len(np.unique([isinstance(row[col], dict) for row in trows])) > 1:
+
+            if len(unique([isinstance(row[col], dict) for row in trows])) > 1:
                 continue  # can't deal with this case
             mshape = np.array(max([np.array(row[col]).shape for row in trows]))
             try:

--- a/src/xradio/vis/_vis_utils/_ms/_tables/read.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read.py
@@ -518,8 +518,6 @@ def read_flat_col_chunk(infile, col, cshape, ridxs, cstart, pstart) -> np.ndarra
     with open_table_ro(infile) as tb_tool:
         rgrps = [
             (rr[0], rr[-1])
-            # TODO
-            # swap np.unique(arr) for np.sort(pd.unique(arr))
             for rr in np.split(ridxs, np.where(np.diff(ridxs) > 1)[0] + 1)
         ]
         # try:

--- a/src/xradio/vis/_vis_utils/_ms/_tables/read.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read.py
@@ -12,7 +12,7 @@ import astropy.units
 from casacore import tables
 
 from .table_query import open_query, open_table_ro
-from xradio.vis._vis_utils._ms.optimised_functions import unique
+from xradio.vis._vis_utils._ms.optimised_functions import unique_1d
 
 CASACORE_TO_PD_TIME_CORRECTION = 3506716800.0
 SECS_IN_DAY = 86400
@@ -429,7 +429,6 @@ def read_generic_cols(
                 [row[col] for row in trows]
             )  # .astype(col_cells[col].dtype)
             if isinstance(trows[0][col], dict):
-                
                 # TODO
                 # benchmark np.stack() performance
                 data = np.stack(
@@ -443,12 +442,12 @@ def read_generic_cols(
         except Exception:
             # sometimes the cols are variable, so we need to standardize to the largest sizes
 
-            if len(unique([isinstance(row[col], dict) for row in trows])) > 1:
+            if len(unique_1d([isinstance(row[col], dict) for row in trows])) > 1:
                 continue  # can't deal with this case
             mshape = np.array(max([np.array(row[col]).shape for row in trows]))
             try:
                 pad_nan = get_pad_nan(col_cells[col])
-                
+
                 # TODO
                 # benchmark np.stack() performance
                 data = np.stack(
@@ -519,7 +518,6 @@ def read_flat_col_chunk(infile, col, cshape, ridxs, cstart, pstart) -> np.ndarra
     with open_table_ro(infile) as tb_tool:
         rgrps = [
             (rr[0], rr[-1])
-            
             # TODO
             # swap np.unique(arr) for np.sort(pd.unique(arr))
             for rr in np.split(ridxs, np.where(np.diff(ridxs) > 1)[0] + 1)
@@ -610,7 +608,7 @@ def read_col_conversion(
     (no need for didxs)
     """
     data = tb_tool.getcol(col)
-    
+
     # TODO
     # check np.full() with np.nan performance vs np.zeros or np.ones
     fulldata = np.full(cshape + data.shape[1:], np.nan, dtype=data.dtype)

--- a/src/xradio/vis/_vis_utils/_ms/_tables/read.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read.py
@@ -423,10 +423,15 @@ def read_generic_cols(
             continue  # not supported
 
         try:
+            # TODO
+            # benchmark np.stack() performance
             data = np.stack(
                 [row[col] for row in trows]
             )  # .astype(col_cells[col].dtype)
             if isinstance(trows[0][col], dict):
+                
+                # TODO
+                # benchmark np.stack() performance
                 data = np.stack(
                     [
                         row[col]["array"].reshape(row[col]["shape"])
@@ -437,11 +442,17 @@ def read_generic_cols(
                 )
         except Exception:
             # sometimes the cols are variable, so we need to standardize to the largest sizes
+            
+            # TODO
+            # swap np.unique(arr) for np.sort(pd.unique(arr))
             if len(np.unique([isinstance(row[col], dict) for row in trows])) > 1:
                 continue  # can't deal with this case
             mshape = np.array(max([np.array(row[col]).shape for row in trows]))
             try:
                 pad_nan = get_pad_nan(col_cells[col])
+                
+                # TODO
+                # benchmark np.stack() performance
                 data = np.stack(
                     [
                         np.pad(
@@ -510,6 +521,9 @@ def read_flat_col_chunk(infile, col, cshape, ridxs, cstart, pstart) -> np.ndarra
     with open_table_ro(infile) as tb_tool:
         rgrps = [
             (rr[0], rr[-1])
+            
+            # TODO
+            # swap np.unique(arr) for np.sort(pd.unique(arr))
             for rr in np.split(ridxs, np.where(np.diff(ridxs) > 1)[0] + 1)
         ]
         # try:
@@ -598,6 +612,9 @@ def read_col_conversion(
     (no need for didxs)
     """
     data = tb_tool.getcol(col)
+    
+    # TODO
+    # check np.full() with np.nan performance vs np.zeros or np.ones
     fulldata = np.full(cshape + data.shape[1:], np.nan, dtype=data.dtype)
     fulldata[tidxs, bidxs] = data
     return fulldata

--- a/src/xradio/vis/_vis_utils/_ms/_tables/read.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read.py
@@ -12,7 +12,6 @@ import astropy.units
 from casacore import tables
 
 from .table_query import open_query, open_table_ro
-from xradio.vis._vis_utils._ms.optimised_functions import unique_1d
 
 CASACORE_TO_PD_TIME_CORRECTION = 3506716800.0
 SECS_IN_DAY = 86400
@@ -442,7 +441,7 @@ def read_generic_cols(
         except Exception:
             # sometimes the cols are variable, so we need to standardize to the largest sizes
 
-            if len(unique_1d([isinstance(row[col], dict) for row in trows])) > 1:
+            if len(set([isinstance(row[col], dict) for row in trows])) > 1:
                 continue  # can't deal with this case
             mshape = np.array(max([np.array(row[col]).shape for row in trows]))
             try:

--- a/src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
@@ -16,7 +16,7 @@ from .read import (
 )
 
 from .table_query import open_table_ro, open_query
-from xradio.vis._vis_utils._ms.optimised_functions import unique
+from xradio.vis._vis_utils._ms.optimised_functions import unique_1d
 
 rename_msv2_cols = {
     "antenna1": "antenna1_id",
@@ -91,9 +91,9 @@ def get_partition_ids(mtable: tables.table, taql_where: str) -> Dict:
     taql_ids = f"select DISTINCT ARRAY_ID, OBSERVATION_ID, PROCESSOR_ID from $mtable {taql_where}"
     with open_query(mtable, taql_ids) as query:
         # array_id, observation_id, processor_id
-        array_id = unique(query.getcol("ARRAY_ID"))
-        obs_id = unique(query.getcol("OBSERVATION_ID"))
-        proc_id = unique(query.getcol("PROCESSOR_ID"))
+        array_id = unique_1d(query.getcol("ARRAY_ID"))
+        obs_id = unique_1d(query.getcol("OBSERVATION_ID"))
+        proc_id = unique_1d(query.getcol("PROCESSOR_ID"))
         check_vars = [
             (array_id, "array_id"),
             (obs_id, "observation_id"),
@@ -209,7 +209,6 @@ def read_main_table_chunks(
             atql = f"ANTENNA1 BETWEEN {ants[0]} and {ants[1]}"
             ts_taql = f"select * from $mtable {taql_where} AND {ttql} AND {atql}"
             with open_query(None, ts_taql) as query_times_ants:
-
                 # TODO
                 # swap np.searchsorted() to njit searchsorted
                 tidxs = (
@@ -268,7 +267,7 @@ def read_main_table_chunks(
 def get_utimes_tol(mtable: tables.table, taql_where: str) -> Tuple[np.ndarray, float]:
     taql_utimes = f"select DISTINCT TIME from $mtable {taql_where}"
     with open_query(mtable, taql_utimes) as query_utimes:
-        utimes = unique(query_utimes.getcol("TIME", 0, -1))
+        utimes = unique_1d(query_utimes.getcol("TIME", 0, -1))
         # add a tol around the time ranges returned by taql
         if len(utimes) < 2:
             tol = 1e-5
@@ -276,7 +275,6 @@ def get_utimes_tol(mtable: tables.table, taql_where: str) -> Tuple[np.ndarray, f
             tol = np.diff(utimes).min() / 4
 
     return utimes, tol
-
 
 
 # TODO

--- a/src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
@@ -274,25 +274,62 @@ def get_utimes_tol(mtable: tables.table, taql_where: str) -> Tuple[np.ndarray, f
 
 
 def get_baselines(tb_tool: tables.table) -> np.ndarray:
+    """Gets the unique baselines from antenna 1 and antenna 2 ids.
+
+    Uses a pairing function and inverse pairing function to decrease the
+    computation time of finding unique values.
+
+    Args:
+        tb_tool (tables.table): MeasurementSet table to get the antenna ids.
+
+    Returns:
+        unique_baselines (np.ndarray): a 2D array of unique antenna pairs
+        (baselines) from the MeasurementSet table provided.
+    """
     ant1, ant2 = tb_tool.getcol("ANTENNA1", 0, -1), tb_tool.getcol("ANTENNA2", 0, -1)
 
     baselines = np.column_stack((ant1, ant2))
+
+    # Using pairing function to reduce the computation time of finding unique values.
     baselines_paired = pairing_function(baselines)
     unique_baselines_paired = pd.unique(baselines_paired)
     unique_baselines = inverse_pairing_function(unique_baselines_paired)
+
+    # Sorting the unique baselines.
     unique_baselines = unique_baselines[unique_baselines[:,1].argsort()]
     unique_baselines = unique_baselines[unique_baselines[:,0].argsort(kind='mergesort')]
 
-    return baselines
+    return unique_baselines
 
 
-def get_baseline_indices(unique_baselines, baseline_set):
+def get_baseline_indices(unique_baselines: np.ndarray, baseline_set: np.ndarray) -> np.ndarray:
+    """Finds the baseline indices of a set of baselines using the unique baselines.
+    
+    Uses a pairing function to reduce the number of values so it's more
+    efficient to find the indices.
+
+    Args:
+        unique_baselines (np.ndarray): a 2D array of unique antenna pairs
+        (baselines).
+        baseline_set (np.ndarray): a 2D array of antenna pairs (baselines). This
+        array may contain duplicates.
+
+    Returns:
+        baseline_indices (np.ndarray): the indices of the baseline set that
+        correspond to the unique baselines.
+    """
     unique_baselines_paired = pairing_function(unique_baselines)
     baseline_set_paired = pairing_function(baseline_set)
+
+    # Pairing function doesn't preserve order so they need to be sorted.
     unique_baselines_sorted = np.argsort(unique_baselines_paired)
-    sorted_indices = np.searchsorted(unique_baselines_paired[unique_baselines_sorted], baseline_set_paired)
-    indices = unique_baselines_sorted[sorted_indices]
-    return indices
+    sorted_indices = np.searchsorted(
+        unique_baselines_paired[unique_baselines_sorted], 
+        baseline_set_paired,
+    )
+    baseline_indices = unique_baselines_sorted[sorted_indices]
+
+    return baseline_indices
 
 
 def read_all_cols_bvars(

--- a/src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
@@ -274,7 +274,6 @@ def get_utimes_tol(mtable: tables.table, taql_where: str) -> Tuple[np.ndarray, f
 
 
 def get_baselines(tb_tool: tables.table) -> np.ndarray:
-    # main table uses time x (antenna1,antenna2)
     ant1, ant2 = tb_tool.getcol("ANTENNA1", 0, -1), tb_tool.getcol("ANTENNA2", 0, -1)
 
     baselines = np.column_stack((ant1, ant2))

--- a/src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
@@ -16,6 +16,7 @@ from .read import (
 )
 
 from .table_query import open_table_ro, open_query
+from xradio.vis._vis_utils._ms.optimised_functions import unique
 
 rename_msv2_cols = {
     "antenna1": "antenna1_id",
@@ -90,12 +91,9 @@ def get_partition_ids(mtable: tables.table, taql_where: str) -> Dict:
     taql_ids = f"select DISTINCT ARRAY_ID, OBSERVATION_ID, PROCESSOR_ID from $mtable {taql_where}"
     with open_query(mtable, taql_ids) as query:
         # array_id, observation_id, processor_id
-    
-        # TODO
-        # swap np.unique(arr) for np.sort(pd.unique(arr))
-        array_id = np.unique(query.getcol("ARRAY_ID"))
-        obs_id = np.unique(query.getcol("OBSERVATION_ID"))
-        proc_id = np.unique(query.getcol("PROCESSOR_ID"))
+        array_id = unique(query.getcol("ARRAY_ID"))
+        obs_id = unique(query.getcol("OBSERVATION_ID"))
+        proc_id = unique(query.getcol("PROCESSOR_ID"))
         check_vars = [
             (array_id, "array_id"),
             (obs_id, "observation_id"),
@@ -270,10 +268,7 @@ def read_main_table_chunks(
 def get_utimes_tol(mtable: tables.table, taql_where: str) -> Tuple[np.ndarray, float]:
     taql_utimes = f"select DISTINCT TIME from $mtable {taql_where}"
     with open_query(mtable, taql_utimes) as query_utimes:
-        
-        # TODO
-        # swap np.unique(arr) for np.sort(pd.unique(arr))
-        utimes = np.unique(query_utimes.getcol("TIME", 0, -1))
+        utimes = unique(query_utimes.getcol("TIME", 0, -1))
         # add a tol around the time ranges returned by taql
         if len(utimes) < 2:
             tol = 1e-5
@@ -289,9 +284,7 @@ def get_utimes_tol(mtable: tables.table, taql_where: str) -> Tuple[np.ndarray, f
 def get_baselines(tb_tool: tables.table) -> np.ndarray:
     # main table uses time x (antenna1,antenna2)
     ant1, ant2 = tb_tool.getcol("ANTENNA1", 0, -1), tb_tool.getcol("ANTENNA2", 0, -1)
-        
-    # TODO
-    # swap np.unique(arr) for np.sort(pd.unique(arr))
+
     # swap string baseline identifiers with integer based cantor pairing
     baselines = np.array(
         [

--- a/src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
@@ -214,8 +214,6 @@ def read_main_table_chunks(
             atql = f"ANTENNA1 BETWEEN {ant1_start} and {ant1_end}"
             ts_taql = f"select * from $mtable {taql_where} AND {ttql} AND {atql}"
             with open_query(None, ts_taql) as query_times_ants:
-                # TODO
-                # swap np.searchsorted() to njit searchsorted
                 tidxs = (
                     np.searchsorted(unique_times, query_times_ants.getcol("TIME", 0, -1)) - time_chunk
                 )

--- a/src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
@@ -90,6 +90,9 @@ def get_partition_ids(mtable: tables.table, taql_where: str) -> Dict:
     taql_ids = f"select DISTINCT ARRAY_ID, OBSERVATION_ID, PROCESSOR_ID from $mtable {taql_where}"
     with open_query(mtable, taql_ids) as query:
         # array_id, observation_id, processor_id
+    
+        # TODO
+        # swap np.unique(arr) for np.sort(pd.unique(arr))
         array_id = np.unique(query.getcol("ARRAY_ID"))
         obs_id = np.unique(query.getcol("OBSERVATION_ID"))
         proc_id = np.unique(query.getcol("PROCESSOR_ID"))
@@ -208,6 +211,9 @@ def read_main_table_chunks(
             atql = f"ANTENNA1 BETWEEN {ants[0]} and {ants[1]}"
             ts_taql = f"select * from $mtable {taql_where} AND {ttql} AND {atql}"
             with open_query(None, ts_taql) as query_times_ants:
+
+                # TODO
+                # swap np.searchsorted() to njit searchsorted
                 tidxs = (
                     np.searchsorted(utimes, query_times_ants.getcol("TIME", 0, -1)) - tc
                 )
@@ -216,10 +222,15 @@ def read_main_table_chunks(
                     query_times_ants.getcol("ANTENNA2", 0, -1),
                 )
 
+            # TODO
+            # swap string baseline identifiers with integer based cantor pairing
             ts_bases = [
                 str(ll[0]).zfill(3) + "_" + str(ll[1]).zfill(3)
                 for ll in np.hstack([ts_ant1[:, None], ts_ant2[:, None]])
             ]
+
+            # TODO
+            # swap np.searchsorted() to njit searchsorted
             bidxs = np.searchsorted(baselines, ts_bases) - bc
 
             # some antenna 2's will be out of bounds for this chunk, store rows that are in bounds
@@ -259,6 +270,9 @@ def read_main_table_chunks(
 def get_utimes_tol(mtable: tables.table, taql_where: str) -> Tuple[np.ndarray, float]:
     taql_utimes = f"select DISTINCT TIME from $mtable {taql_where}"
     with open_query(mtable, taql_utimes) as query_utimes:
+        
+        # TODO
+        # swap np.unique(arr) for np.sort(pd.unique(arr))
         utimes = np.unique(query_utimes.getcol("TIME", 0, -1))
         # add a tol around the time ranges returned by taql
         if len(utimes) < 2:
@@ -269,9 +283,16 @@ def get_utimes_tol(mtable: tables.table, taql_where: str) -> Tuple[np.ndarray, f
     return utimes, tol
 
 
+
+# TODO
+# swap string baseline identifiers with integer based cantor pairing
 def get_baselines(tb_tool: tables.table) -> np.ndarray:
     # main table uses time x (antenna1,antenna2)
     ant1, ant2 = tb_tool.getcol("ANTENNA1", 0, -1), tb_tool.getcol("ANTENNA2", 0, -1)
+        
+    # TODO
+    # swap np.unique(arr) for np.sort(pd.unique(arr))
+    # swap string baseline identifiers with integer based cantor pairing
     baselines = np.array(
         [
             str(ll[0]).zfill(3) + "_" + str(ll[1]).zfill(3)

--- a/src/xradio/vis/_vis_utils/_ms/_tables/read_subtables.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read_subtables.py
@@ -19,6 +19,7 @@ from .read import (
     read_generic_table,
 )
 from .write import revert_time
+from xradio.vis._vis_utils._ms.optimised_functions import unique_1d
 
 
 def read_ephemerides(
@@ -86,10 +87,10 @@ def read_delayed_pointing_table(
                 return xr.Dataset()
 
             # pointing table uses time x antenna_id
-            antennas = np.unique(query_all.getcol("ANTENNA_ID", 0, -1))
+            antennas = unique_1d(query_all.getcol("ANTENNA_ID", 0, -1))
             taql_times = f"select DISTINCT TIME from $mtable {taql_time}"
             with open_query(None, taql_times) as query_times:
-                utimes = np.unique(query_times.getcol("TIME", 0, -1))
+                utimes = unique_1d(query_times.getcol("TIME", 0, -1))
 
             tvars = read_delayed_pointing_times(
                 infile, antennas, utimes, chunks, query_all, times
@@ -150,7 +151,7 @@ def normalize_time_slice(mtable: tables.table, time_slice: slice):
         # instead of int cast could be operator.index(time_slice.start)
         taql_utimes = "select DISTINCT TIME from $mtable"
         with open_query(mtable, taql_utimes) as query_utimes:
-            utimes = np.unique(query_utimes.getcol("TIME", 0, -1))
+            utimes = unique_1d(query_utimes.getcol("TIME", 0, -1))
             # add a tol around the time ranges returned by taql
             if len(utimes) < 2:
                 tol = 1e-5

--- a/src/xradio/vis/_vis_utils/_ms/chunks.py
+++ b/src/xradio/vis/_vis_utils/_ms/chunks.py
@@ -13,7 +13,7 @@ from ._tables.read import read_generic_table, make_freq_attrs
 from ._tables.read_subtables import read_delayed_pointing_table
 from .._utils.partition_attrs import add_partition_attrs
 from .._utils.xds_helper import make_coords
-
+from xradio.vis._vis_utils._ms.optimised_functions import unique_1d
 
 def read_spw_ddi_ant_pol(inpath: str) -> Tuple[xr.Dataset]:
     """
@@ -66,7 +66,7 @@ def load_main_chunk(
     data_desc_id, scan_number, state_id = make_partition_ids_by_ddi_scan(infile, False)
 
     all_xdss = {}
-    data_desc_id = np.unique(data_desc_id)
+    data_desc_id = unique_1d(data_desc_id)
     for ddi in data_desc_id:
         xds, part_ids, attrs = load_expanded_main_table_chunk(
             infile, ddi, chunk, ignore_msv2_cols=ignore_msv2_cols

--- a/src/xradio/vis/_vis_utils/_ms/conversion.py
+++ b/src/xradio/vis/_vis_utils/_ms/conversion.py
@@ -62,8 +62,6 @@ def calc_indx_for_row_split(tb_tool, taql_where):
     freq_cnt, pol_cnt = [(cc[0], cc[1]) for cc in cshapes if len(cc) == 2][0]
     utimes, tol = get_utimes_tol(tb_tool, taql_where)
 
-    # TODO
-    # swap np.searchsorted() to njit searchsorted
     tidxs = np.searchsorted(utimes, tb_tool.getcol("TIME"))
 
     ts_ant1, ts_ant2 = (
@@ -71,28 +69,16 @@ def calc_indx_for_row_split(tb_tool, taql_where):
         tb_tool.getcol("ANTENNA2"),
     )
 
-    # TODO
-    # swap string baseline identifiers with integer based cantor pairing
-    ts_bases = [
-        str(ll[0]).zfill(3) + "_" + str(ll[1]).zfill(3)
-        for ll in np.hstack([ts_ant1[:, None], ts_ant2[:, None]])
-    ]
-
-    # TODO
-    # swap np.searchsorted() to njit searchsorted
+    ts_bases = np.column_stack((ts_ant1, ts_ant2))
     bidxs = np.searchsorted(baselines, ts_bases)
 
     # some antenna 2"s will be out of bounds for this chunk, store rows that are in bounds
 
-    # TODO
-    # swap string baseline identifiers with integer based cantor pairing
     didxs = np.where((bidxs >= 0) & (bidxs < len(baselines)))[0]
 
-    # TODO
-    # swap string baseline identifiers with integer based cantor pairing
-    baseline_ant1_id, baseline_ant2_id = np.array(
-        [tuple(map(int, x.split("_"))) for x in baselines]
-    ).T
+    baseline_ant1_id = baselines[:, 0]
+    baseline_ant2_id = baselines[:, 1]
+
     return (
         tidxs,
         bidxs,

--- a/src/xradio/vis/_vis_utils/_ms/conversion.py
+++ b/src/xradio/vis/_vis_utils/_ms/conversion.py
@@ -25,7 +25,7 @@ from ._tables.read import (
 )
 from ._tables.read_main_table import get_baselines, get_utimes_tol
 from .._utils.stokes_types import stokes_types
-from xradio.vis._vis_utils._ms.optimised_functions import unique
+from xradio.vis._vis_utils._ms.optimised_functions import unique_1d
 
 
 def check_if_consistent(col, col_name):
@@ -44,7 +44,7 @@ def check_if_consistent(col, col_name):
         _description_
     """
 
-    col_unique = unique(col)
+    col_unique = unique_1d(col)
     assert len(col_unique) == 1, col_name + " is not consistent."
     return col_unique[0]
 
@@ -83,11 +83,10 @@ def calc_indx_for_row_split(tb_tool, taql_where):
     bidxs = np.searchsorted(baselines, ts_bases)
 
     # some antenna 2"s will be out of bounds for this chunk, store rows that are in bounds
-    
+
     # TODO
     # swap string baseline identifiers with integer based cantor pairing
     didxs = np.where((bidxs >= 0) & (bidxs < len(baselines)))[0]
-    
 
     # TODO
     # swap string baseline identifiers with integer based cantor pairing
@@ -166,7 +165,7 @@ def create_coordinates(
     # xds.frequency.attrs["doppler_velocity"] =
     # xds.frequency.attrs["doppler_type"] =
 
-    unique_chan_width = unique(
+    unique_chan_width = unique_1d(
         spw_xds.chan_width.data[np.logical_not(np.isnan(spw_xds.chan_width.data))]
     )
     # assert len(unique_chan_width) == 1, "Channel width varies for spw."
@@ -331,12 +330,14 @@ def convert_and_write_partition(
             # logging.debug("Calc indx for row split "+ str(time.time()-start))
 
             xds = xr.Dataset()
-            #interval = check_if_consistent(tb_tool.getcol("INTERVAL"), "INTERVAL")
+            # interval = check_if_consistent(tb_tool.getcol("INTERVAL"), "INTERVAL")
             interval = tb_tool.getcol("INTERVAL")
 
-            interval_unique = unique(interval)
+            interval_unique = unique_1d(interval)
             if len(interval_unique) > 1:
-                print('Integration time (interval) not consitent in partition, using median.')
+                print(
+                    "Integration time (interval) not consitent in partition, using median."
+                )
                 interval = np.median(interval)
             else:
                 interval = interval_unique[0]

--- a/src/xradio/vis/_vis_utils/_ms/conversion.py
+++ b/src/xradio/vis/_vis_utils/_ms/conversion.py
@@ -23,7 +23,7 @@ from ._tables.read import (
     read_col_conversion,
     read_generic_table,
 )
-from ._tables.read_main_table import get_baselines, get_utimes_tol
+from ._tables.read_main_table import get_baselines, get_baseline_indices, get_utimes_tol
 from .._utils.stokes_types import stokes_types
 from xradio.vis._vis_utils._ms.optimised_functions import unique_1d
 
@@ -70,7 +70,7 @@ def calc_indx_for_row_split(tb_tool, taql_where):
     )
 
     ts_bases = np.column_stack((ts_ant1, ts_ant2))
-    bidxs = np.searchsorted(baselines, ts_bases)
+    bidxs = get_baseline_indices(baselines, ts_bases)
 
     # some antenna 2"s will be out of bounds for this chunk, store rows that are in bounds
 

--- a/src/xradio/vis/_vis_utils/_ms/conversion.py
+++ b/src/xradio/vis/_vis_utils/_ms/conversion.py
@@ -25,6 +25,7 @@ from ._tables.read import (
 )
 from ._tables.read_main_table import get_baselines, get_utimes_tol
 from .._utils.stokes_types import stokes_types
+from xradio.vis._vis_utils._ms.optimised_functions import unique
 
 
 def check_if_consistent(col, col_name):
@@ -42,10 +43,8 @@ def check_if_consistent(col, col_name):
     _type_
         _description_
     """
-    
-    # TODO
-    # swap np.unique(arr) for np.sort(pd.unique(arr))
-    col_unique = np.unique(col)
+
+    col_unique = unique(col)
     assert len(col_unique) == 1, col_name + " is not consistent."
     return col_unique[0]
 
@@ -62,10 +61,6 @@ def calc_indx_for_row_split(tb_tool, taql_where):
 
     freq_cnt, pol_cnt = [(cc[0], cc[1]) for cc in cshapes if len(cc) == 2][0]
     utimes, tol = get_utimes_tol(tb_tool, taql_where)
-    
-    # TODO
-    # swap np.unique(arr) for np.sort(pd.unique(arr))
-    # utimes = np.unique(tb_tool.getcol("TIME"))
 
     # TODO
     # swap np.searchsorted() to njit searchsorted
@@ -170,10 +165,8 @@ def create_coordinates(
     # Add if doppler table is present
     # xds.frequency.attrs["doppler_velocity"] =
     # xds.frequency.attrs["doppler_type"] =
-    
-    # TODO
-    # swap np.unique(arr) for np.sort(pd.unique(arr))
-    unique_chan_width = np.unique(
+
+    unique_chan_width = unique(
         spw_xds.chan_width.data[np.logical_not(np.isnan(spw_xds.chan_width.data))]
     )
     # assert len(unique_chan_width) == 1, "Channel width varies for spw."
@@ -340,10 +333,8 @@ def convert_and_write_partition(
             xds = xr.Dataset()
             #interval = check_if_consistent(tb_tool.getcol("INTERVAL"), "INTERVAL")
             interval = tb_tool.getcol("INTERVAL")
-            
-            # TODO
-            # swap np.unique(arr) for np.sort(pd.unique(arr))
-            interval_unique = np.unique(interval)
+
+            interval_unique = unique(interval)
             if len(interval_unique) > 1:
                 print('Integration time (interval) not consitent in partition, using median.')
                 interval = np.median(interval)

--- a/src/xradio/vis/_vis_utils/_ms/conversion.py
+++ b/src/xradio/vis/_vis_utils/_ms/conversion.py
@@ -42,6 +42,9 @@ def check_if_consistent(col, col_name):
     _type_
         _description_
     """
+    
+    # TODO
+    # swap np.unique(arr) for np.sort(pd.unique(arr))
     col_unique = np.unique(col)
     assert len(col_unique) == 1, col_name + " is not consistent."
     return col_unique[0]
@@ -59,8 +62,13 @@ def calc_indx_for_row_split(tb_tool, taql_where):
 
     freq_cnt, pol_cnt = [(cc[0], cc[1]) for cc in cshapes if len(cc) == 2][0]
     utimes, tol = get_utimes_tol(tb_tool, taql_where)
+    
+    # TODO
+    # swap np.unique(arr) for np.sort(pd.unique(arr))
     # utimes = np.unique(tb_tool.getcol("TIME"))
 
+    # TODO
+    # swap np.searchsorted() to njit searchsorted
     tidxs = np.searchsorted(utimes, tb_tool.getcol("TIME"))
 
     ts_ant1, ts_ant2 = (
@@ -68,15 +76,26 @@ def calc_indx_for_row_split(tb_tool, taql_where):
         tb_tool.getcol("ANTENNA2"),
     )
 
+    # TODO
+    # swap string baseline identifiers with integer based cantor pairing
     ts_bases = [
         str(ll[0]).zfill(3) + "_" + str(ll[1]).zfill(3)
         for ll in np.hstack([ts_ant1[:, None], ts_ant2[:, None]])
     ]
+
+    # TODO
+    # swap np.searchsorted() to njit searchsorted
     bidxs = np.searchsorted(baselines, ts_bases)
 
     # some antenna 2"s will be out of bounds for this chunk, store rows that are in bounds
+    
+    # TODO
+    # swap string baseline identifiers with integer based cantor pairing
     didxs = np.where((bidxs >= 0) & (bidxs < len(baselines)))[0]
+    
 
+    # TODO
+    # swap string baseline identifiers with integer based cantor pairing
     baseline_ant1_id, baseline_ant2_id = np.array(
         [tuple(map(int, x.split("_"))) for x in baselines]
     ).T
@@ -151,6 +170,9 @@ def create_coordinates(
     # Add if doppler table is present
     # xds.frequency.attrs["doppler_velocity"] =
     # xds.frequency.attrs["doppler_type"] =
+    
+    # TODO
+    # swap np.unique(arr) for np.sort(pd.unique(arr))
     unique_chan_width = np.unique(
         spw_xds.chan_width.data[np.logical_not(np.isnan(spw_xds.chan_width.data))]
     )
@@ -318,6 +340,9 @@ def convert_and_write_partition(
             xds = xr.Dataset()
             #interval = check_if_consistent(tb_tool.getcol("INTERVAL"), "INTERVAL")
             interval = tb_tool.getcol("INTERVAL")
+            
+            # TODO
+            # swap np.unique(arr) for np.sort(pd.unique(arr))
             interval_unique = np.unique(interval)
             if len(interval_unique) > 1:
                 print('Integration time (interval) not consitent in partition, using median.')

--- a/src/xradio/vis/_vis_utils/_ms/descr.py
+++ b/src/xradio/vis/_vis_utils/_ms/descr.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from ._tables.read import read_generic_table, read_flat_col_chunk
 from ._tables.table_query import open_query, open_table_ro
+from xradio.vis._vis_utils._ms.optimised_functions import unique_1d
 
 
 def describe_ms(
@@ -94,7 +95,7 @@ def populate_ms_descr(
         ]
         sdf.update(
             {
-                "times": len(np.unique(times)),
+                "times": len(unique_1d(times)),
                 "baselines": len(np.unique(np.hstack(baselines), axis=0)),
             }
         )

--- a/src/xradio/vis/_vis_utils/_ms/optimised_array_operations.py
+++ b/src/xradio/vis/_vis_utils/_ms/optimised_array_operations.py
@@ -1,0 +1,136 @@
+########################################################################
+# module which contains optimised functions to be called by other utilities
+
+
+########################################################################
+# list of affected files:
+# - src/xradio/vis/_vis_utils/_ms/conversion.py
+# - src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
+# - src/xradio/vis/_vis_utils/_ms/_tables/read.py
+# - src/xradio/vis/_vis_utils/_ms/partition_queries.py
+
+
+########################################################################
+# function changes to be made:
+
+
+# np.unique() -> unique()
+
+
+# ts_bases = [
+#         str(ll[0]).zfill(3) + "_" + str(ll[1]).zfill(3)
+#         for ll in np.hstack([ts_ant1[:, None], ts_ant2[:, None]])
+#     ] ->
+# ts_bases -> antennas_to_baselines(ts_ant1, ts_ant2)
+
+
+# np.searchsorted() -> searchsorted()
+
+
+# baseline_ant1_id, baseline_ant2_id = np.array(
+#         [tuple(map(int, x.split("_"))) for x in baselines]
+#     ).T ->
+# baseline_ant1_id, baseline_ant2_id = baselines_to_antennas()
+
+
+
+
+
+########################################################################
+
+# NOTE: the function get_baselines() in read_main_table module is distinct 
+# from the above operation baselines_to_antennas() as it first gets the unique 
+# antennas in each column. The function get_baselines() can either be brought 
+# into this module, or optimised in place
+
+
+
+########################################################################
+# functions to test
+import numpy as np
+import pandas as pd
+from casacore import tables
+# TODO check numba is a dependency
+import numba as nb
+
+
+
+def unique(arr):
+    return np.unique(arr)
+
+# Optimised function
+# def unique(arr):
+#     return np.sort(pd.unique(arr))
+
+
+
+
+# returns a np.ndarray with dtype=str
+def antennas_to_baselines(ant1: np.ndarray, ant2: np.ndarray) -> np.ndarray:
+    baselines = [
+            str(ll[0]).zfill(3) + "_" + str(ll[1]).zfill(3)
+            for ll in np.hstack([ant1[:, None], ant2[:, None]])
+        ]
+    return baselines
+
+# Optimised function
+# returns a np.ndarray with dtype=np.int32
+# @nb.njit(parallel=False, fastmath=True)
+# def antennas_to_baselines(ant1, ant2):
+#     all_baselines = np.empty(ant1.size, dtype=np.int32)
+    
+#     for i in nb.prange(len(ant1)):
+#         # This is a Cantor pairing funciton
+#         # max_num_antenna_pairs required to give expected ordering (20000 may be too small for certain SKA-low observations)
+#         # see https://math.stackexchange.com/questions/3212587/does-there-exist-a-pairing-function-which-preserves-ordering
+#         # and https://math.stackexchange.com/questions/3969617/what-pairing-function-coincides-with-the-g%C3%B6del-pairing-on-the-natural-numbers
+#         max_num_antenna_pairs = 20000
+#         all_baselines[i] = ((ant1[i] + ant2[i]) * (ant1[i] + ant2[i] + 1)) // 2 + max_num_antenna_pairs*ant1[i]
+
+
+
+def searchsorted(arr1: np.ndarray, arr2: np.ndarray) -> np.ndarray:
+    return np.searchsorted(arr1, arr2)
+
+# Optimised function
+# @nb.njit(parallel=False, fastmath=True)
+# def searchsorted(arr1: np.ndarray, arr2: np.ndarray) -> np.ndarray:
+#     res = np.empty(len(arr2), np.intp)
+#     for i in nb.prange(len(arr2)):
+#         res[i] = np.searchsorted(arr1, arr2[i])
+#     return res
+    
+
+
+
+########################################################################
+# special case for get_baselines() in read_main_table
+# will use a combination of functions
+
+# current function (copied from read_main_table.py)
+def get_baselines(tb_tool: tables.table) -> np.ndarray:
+    # main table uses time x (antenna1,antenna2)
+    ant1, ant2 = tb_tool.getcol("ANTENNA1", 0, -1), tb_tool.getcol("ANTENNA2", 0, -1)
+        
+    # TODO
+    # swap np.unique(arr) for np.sort(pd.unique(arr))
+    # swap string baseline identifiers with integer based cantor pairing
+    baselines = np.array(
+        [
+            str(ll[0]).zfill(3) + "_" + str(ll[1]).zfill(3)
+            for ll in np.unique(np.hstack([ant1[:, None], ant2[:, None]]), axis=0)
+        ]
+    )
+
+    return baselines
+
+
+# Optimised function
+# get_baselines(tb_tool: tables.table) -> np.ndarray:
+#     # main table uses time x (antenna1,antenna2)
+#     ant1, ant2 = tb_tool.getcol("ANTENNA1", 0, -1), tb_tool.getcol("ANTENNA2", 0, -1)
+#     
+#     baselines = np.sort(np.unique(antennas_to_baselines(ant1, ant2)))
+#     
+#     return baselines
+# TODO check above function is correct. Only quickly scanned through msconverter and may be wrong

--- a/src/xradio/vis/_vis_utils/_ms/optimised_functions.py
+++ b/src/xradio/vis/_vis_utils/_ms/optimised_functions.py
@@ -1,6 +1,5 @@
 """Contains optimised functions to be used within other modules."""
 
-from typing import Union
 import numpy as np
 import pandas as pd
 

--- a/src/xradio/vis/_vis_utils/_ms/optimised_functions.py
+++ b/src/xradio/vis/_vis_utils/_ms/optimised_functions.py
@@ -14,9 +14,6 @@
 # function changes to be made:
 
 
-# np.unique() -> unique()
-
-
 # ts_bases = [
 #         str(ll[0]).zfill(3) + "_" + str(ll[1]).zfill(3)
 #         for ll in np.hstack([ts_ant1[:, None], ts_ant2[:, None]])
@@ -33,9 +30,6 @@
 # baseline_ant1_id, baseline_ant2_id = baselines_to_antennas()
 
 
-
-
-
 ########################################################################
 
 # NOTE: the function get_baselines() in read_main_table module is distinct 
@@ -47,21 +41,23 @@
 
 ########################################################################
 # functions to test
+from typing import Union
 import numpy as np
 import pandas as pd
 from casacore import tables
-# TODO check numba is a dependency
-import numba as nb
 
 
 
-def unique(arr):
-    return np.unique(arr)
+def unique(array: Union[np.ndarray, list]) -> np.ndarray:
+    """Optimised version of np.unique for 1D arrays.
+    
+    Args:
+        array (np.ndarray/list): a 1D array or list of values.
 
-# Optimised function
-# def unique(arr):
-#     return np.sort(pd.unique(arr))
-
+    Returns:
+        np.ndarray: a sorted array of unique values.
+    """
+    return np.sort(pd.unique(array))
 
 
 

--- a/src/xradio/vis/_vis_utils/_ms/optimised_functions.py
+++ b/src/xradio/vis/_vis_utils/_ms/optimised_functions.py
@@ -5,11 +5,11 @@ import numpy as np
 import pandas as pd
 
 
-def unique_1d(array: Union[np.ndarray, list]) -> np.ndarray:
+def unique_1d(array: np.ndarray) -> np.ndarray:
     """Optimised version of np.unique for 1D arrays.
 
     Args:
-        array (np.ndarray/list): a 1D array or list of values.
+        array (np.ndarray): a 1D array of values.
 
     Returns:
         np.ndarray: a sorted array of unique values.
@@ -17,9 +17,31 @@ def unique_1d(array: Union[np.ndarray, list]) -> np.ndarray:
     return np.sort(pd.unique(array))
 
 
-def pairing_function(antenna_pairs):
+def pairing_function(antenna_pairs: np.ndarray) -> np.ndarray:
+    """Pairing function to convert each array pair to a single value.
+    
+    This custom pairing function will only work if the maximum value is less
+    than 2**20 and less than 2,048 if using signed 32-bit integers.
+    
+    Args:
+        antenna_pairs (np.ndarray): a 2D array containing antenna 1 and antenna
+        2 ids, which forms a baseline.
+
+    Returns:
+        np.ndarray: a 1D array of the paired values.
+    """
     return antenna_pairs[:, 0] * 2**20 + antenna_pairs[:, 1]
 
 
-def inverse_pairing_function(x):
-    return np.column_stack(np.divmod(x, 2**20))
+def inverse_pairing_function(paired_array: np.ndarray) -> np.ndarray:
+    """Inverse pairing function to convert each paired value to an antenna pair.
+    
+    This inverse pairing function is the inverse of the custom pairing function.
+    
+    Args:
+        paired_array (np.ndarray): a 1D array of the paired values.
+
+    Returns:
+        np.ndarray: a 2D array containing antenna 1 and antenna 2 ids.
+    """
+    return np.column_stack(np.divmod(paired_array, 2**20))

--- a/src/xradio/vis/_vis_utils/_ms/optimised_functions.py
+++ b/src/xradio/vis/_vis_utils/_ms/optimised_functions.py
@@ -18,10 +18,10 @@ def unique_1d(array: np.ndarray) -> np.ndarray:
 
 def pairing_function(antenna_pairs: np.ndarray) -> np.ndarray:
     """Pairing function to convert each array pair to a single value.
-    
+
     This custom pairing function will only work if the maximum value is less
     than 2**20 and less than 2,048 if using signed 32-bit integers.
-    
+
     Args:
         antenna_pairs (np.ndarray): a 2D array containing antenna 1 and antenna
         2 ids, which forms a baseline.
@@ -34,9 +34,9 @@ def pairing_function(antenna_pairs: np.ndarray) -> np.ndarray:
 
 def inverse_pairing_function(paired_array: np.ndarray) -> np.ndarray:
     """Inverse pairing function to convert each paired value to an antenna pair.
-    
+
     This inverse pairing function is the inverse of the custom pairing function.
-    
+
     Args:
         paired_array (np.ndarray): a 1D array of the paired values.
 

--- a/src/xradio/vis/_vis_utils/_ms/optimised_functions.py
+++ b/src/xradio/vis/_vis_utils/_ms/optimised_functions.py
@@ -1,5 +1,4 @@
-########################################################################
-# module which contains optimised functions to be called by other utilities
+"""Contains optimised functions to be used within other modules."""
 
 
 ########################################################################
@@ -21,9 +20,6 @@
 # ts_bases -> antennas_to_baselines(ts_ant1, ts_ant2)
 
 
-# np.searchsorted() -> searchsorted()
-
-
 # baseline_ant1_id, baseline_ant2_id = np.array(
 #         [tuple(map(int, x.split("_"))) for x in baselines]
 #     ).T ->
@@ -32,11 +28,10 @@
 
 ########################################################################
 
-# NOTE: the function get_baselines() in read_main_table module is distinct 
-# from the above operation baselines_to_antennas() as it first gets the unique 
-# antennas in each column. The function get_baselines() can either be brought 
+# NOTE: the function get_baselines() in read_main_table module is distinct
+# from the above operation baselines_to_antennas() as it first gets the unique
+# antennas in each column. The function get_baselines() can either be brought
 # into this module, or optimised in place
-
 
 
 ########################################################################
@@ -47,10 +42,9 @@ import pandas as pd
 from casacore import tables
 
 
-
-def unique(array: Union[np.ndarray, list]) -> np.ndarray:
+def unique_1d(array: Union[np.ndarray, list]) -> np.ndarray:
     """Optimised version of np.unique for 1D arrays.
-    
+
     Args:
         array (np.ndarray/list): a 1D array or list of values.
 
@@ -60,33 +54,9 @@ def unique(array: Union[np.ndarray, list]) -> np.ndarray:
     return np.sort(pd.unique(array))
 
 
-
-# returns a np.ndarray with dtype=str
-def antennas_to_baselines(ant1: np.ndarray, ant2: np.ndarray) -> np.ndarray:
-    baselines = [
-            str(ll[0]).zfill(3) + "_" + str(ll[1]).zfill(3)
-            for ll in np.hstack([ant1[:, None], ant2[:, None]])
-        ]
-    return baselines
-
-# Optimised function
-# returns a np.ndarray with dtype=np.int32
-# @nb.njit(parallel=False, fastmath=True)
-# def antennas_to_baselines(ant1, ant2):
-#     all_baselines = np.empty(ant1.size, dtype=np.int32)
-    
-#     for i in nb.prange(len(ant1)):
-#         # This is a Cantor pairing funciton
-#         # max_num_antenna_pairs required to give expected ordering (20000 may be too small for certain SKA-low observations)
-#         # see https://math.stackexchange.com/questions/3212587/does-there-exist-a-pairing-function-which-preserves-ordering
-#         # and https://math.stackexchange.com/questions/3969617/what-pairing-function-coincides-with-the-g%C3%B6del-pairing-on-the-natural-numbers
-#         max_num_antenna_pairs = 20000
-#         all_baselines[i] = ((ant1[i] + ant2[i]) * (ant1[i] + ant2[i] + 1)) // 2 + max_num_antenna_pairs*ant1[i]
-
-
-
 def searchsorted(arr1: np.ndarray, arr2: np.ndarray) -> np.ndarray:
     return np.searchsorted(arr1, arr2)
+
 
 # Optimised function
 # @nb.njit(parallel=False, fastmath=True)
@@ -95,38 +65,21 @@ def searchsorted(arr1: np.ndarray, arr2: np.ndarray) -> np.ndarray:
 #     for i in nb.prange(len(arr2)):
 #         res[i] = np.searchsorted(arr1, arr2[i])
 #     return res
-    
 
 
-
-########################################################################
-# special case for get_baselines() in read_main_table
-# will use a combination of functions
-
-# current function (copied from read_main_table.py)
-def get_baselines(tb_tool: tables.table) -> np.ndarray:
-    # main table uses time x (antenna1,antenna2)
-    ant1, ant2 = tb_tool.getcol("ANTENNA1", 0, -1), tb_tool.getcol("ANTENNA2", 0, -1)
-        
-    # TODO
-    # swap np.unique(arr) for np.sort(pd.unique(arr))
-    # swap string baseline identifiers with integer based cantor pairing
-    baselines = np.array(
-        [
-            str(ll[0]).zfill(3) + "_" + str(ll[1]).zfill(3)
-            for ll in np.unique(np.hstack([ant1[:, None], ant2[:, None]]), axis=0)
-        ]
-    )
-
+# returns a np.ndarray with dtype=str
+def antennas_to_baselines(ant1: np.ndarray, ant2: np.ndarray) -> np.ndarray:
+    baselines = [
+        str(ll[0]).zfill(3) + "_" + str(ll[1]).zfill(3)
+        for ll in np.hstack([ant1[:, None], ant2[:, None]])
+    ]
     return baselines
 
 
-# Optimised function
-# get_baselines(tb_tool: tables.table) -> np.ndarray:
-#     # main table uses time x (antenna1,antenna2)
-#     ant1, ant2 = tb_tool.getcol("ANTENNA1", 0, -1), tb_tool.getcol("ANTENNA2", 0, -1)
-#     
-#     baselines = np.sort(np.unique(antennas_to_baselines(ant1, ant2)))
-#     
-#     return baselines
-# TODO check above function is correct. Only quickly scanned through msconverter and may be wrong
+def get_baselines(tb_tool: tables.table) -> np.ndarray:
+    # main table uses time x (antenna1,antenna2)
+    ant1, ant2 = tb_tool.getcol("ANTENNA1", 0, -1), tb_tool.getcol("ANTENNA2", 0, -1)
+
+    baselines = np.unique(np.column_stack((ant1, ant2)), axis=0)
+
+    return baselines

--- a/src/xradio/vis/_vis_utils/_ms/optimised_functions.py
+++ b/src/xradio/vis/_vis_utils/_ms/optimised_functions.py
@@ -1,45 +1,8 @@
 """Contains optimised functions to be used within other modules."""
 
-
-########################################################################
-# list of affected files:
-# - src/xradio/vis/_vis_utils/_ms/conversion.py
-# - src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
-# - src/xradio/vis/_vis_utils/_ms/_tables/read.py
-# - src/xradio/vis/_vis_utils/_ms/partition_queries.py
-
-
-########################################################################
-# function changes to be made:
-
-
-# ts_bases = [
-#         str(ll[0]).zfill(3) + "_" + str(ll[1]).zfill(3)
-#         for ll in np.hstack([ts_ant1[:, None], ts_ant2[:, None]])
-#     ] ->
-# ts_bases -> antennas_to_baselines(ts_ant1, ts_ant2)
-
-
-# baseline_ant1_id, baseline_ant2_id = np.array(
-#         [tuple(map(int, x.split("_"))) for x in baselines]
-#     ).T ->
-# baseline_ant1_id, baseline_ant2_id = baselines_to_antennas()
-
-
-########################################################################
-
-# NOTE: the function get_baselines() in read_main_table module is distinct
-# from the above operation baselines_to_antennas() as it first gets the unique
-# antennas in each column. The function get_baselines() can either be brought
-# into this module, or optimised in place
-
-
-########################################################################
-# functions to test
 from typing import Union
 import numpy as np
 import pandas as pd
-from casacore import tables
 
 
 def unique_1d(array: Union[np.ndarray, list]) -> np.ndarray:
@@ -54,32 +17,9 @@ def unique_1d(array: Union[np.ndarray, list]) -> np.ndarray:
     return np.sort(pd.unique(array))
 
 
-def searchsorted(arr1: np.ndarray, arr2: np.ndarray) -> np.ndarray:
-    return np.searchsorted(arr1, arr2)
+def pairing_function(antenna_pairs):
+    return antenna_pairs[:, 0] * 2**20 + antenna_pairs[:, 1]
 
 
-# Optimised function
-# @nb.njit(parallel=False, fastmath=True)
-# def searchsorted(arr1: np.ndarray, arr2: np.ndarray) -> np.ndarray:
-#     res = np.empty(len(arr2), np.intp)
-#     for i in nb.prange(len(arr2)):
-#         res[i] = np.searchsorted(arr1, arr2[i])
-#     return res
-
-
-# returns a np.ndarray with dtype=str
-def antennas_to_baselines(ant1: np.ndarray, ant2: np.ndarray) -> np.ndarray:
-    baselines = [
-        str(ll[0]).zfill(3) + "_" + str(ll[1]).zfill(3)
-        for ll in np.hstack([ant1[:, None], ant2[:, None]])
-    ]
-    return baselines
-
-
-def get_baselines(tb_tool: tables.table) -> np.ndarray:
-    # main table uses time x (antenna1,antenna2)
-    ant1, ant2 = tb_tool.getcol("ANTENNA1", 0, -1), tb_tool.getcol("ANTENNA2", 0, -1)
-
-    baselines = np.unique(np.column_stack((ant1, ant2)), axis=0)
-
-    return baselines
+def inverse_pairing_function(x):
+    return np.column_stack(np.divmod(x, 2**20))

--- a/src/xradio/vis/_vis_utils/_ms/partition_queries.py
+++ b/src/xradio/vis/_vis_utils/_ms/partition_queries.py
@@ -49,7 +49,7 @@ def make_partition_ids_by_ddi_scan(
             )
             if do_subscans:
                 state_id = query_states.getcol("STATE_ID")
-                data_desc_id = [None] * len(scan_number)
+                data_desc_id = np.full(len(scan_number), None)
             else:
                 state_id = [None] * len(scan_number)
                 logging.debug(f"Got col STATE_ID (len: {len(state_id)}): {state_id}")

--- a/tests/unit/vis/_vis_utils/_ms/test_optimised_functions.py
+++ b/tests/unit/vis/_vis_utils/_ms/test_optimised_functions.py
@@ -1,3 +1,59 @@
+import pytest
+import numpy as np
 import xradio.vis._vis_utils._ms.optimised_functions as opt
 
+
+@pytest.mark.parametrize(
+    "input_array, expected_unique_array",
+    [
+        (
+            np.array(
+                [
+                    1,
+                    1,
+                    1,
+                    2,
+                    2,
+                    2,
+                    3,
+                    3,
+                    3,
+                ]
+            ),
+            np.array([1, 2, 3]),
+        ),
+        (
+            np.array(
+                [
+                    1,
+                    1,
+                    1,
+                    2,
+                    4,
+                    3
+                ]
+            ),
+            np.array([1, 2, 3, 4]),
+        ),
+        (
+            np.array(
+                [
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1
+                ]
+            ),
+            np.array([1]),
+        )
+    ],
+)
+def test_unique_1d(input_array, expected_unique_array):
+    # Act
+    unique_array = opt.unique_1d(input_array)
+
+    # Assert
+    np.testing.assert_array_almost_equal(unique_array, expected_unique_array)
 

--- a/tests/unit/vis/_vis_utils/_ms/test_optimised_functions.py
+++ b/tests/unit/vis/_vis_utils/_ms/test_optimised_functions.py
@@ -1,0 +1,3 @@
+import xradio.vis._vis_utils._ms.optimised_functions as opt
+
+

--- a/tests/unit/vis/_vis_utils/_ms/test_optimised_functions.py
+++ b/tests/unit/vis/_vis_utils/_ms/test_optimised_functions.py
@@ -23,29 +23,11 @@ import xradio.vis._vis_utils._ms.optimised_functions as opt
             np.array([1, 2, 3]),
         ),
         (
-            np.array(
-                [
-                    1,
-                    1,
-                    1,
-                    2,
-                    4,
-                    3
-                ]
-            ),
+            np.array([1, 1, 1, 2, 4, 3]),
             np.array([1, 2, 3, 4]),
         ),
         (
-            np.array(
-                [
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1
-                ]
-            ),
+            np.array([1, 1, 1, 1, 1, 1]),
             np.array([1]),
         ),
     ],
@@ -56,3 +38,83 @@ def test_unique_1d(input_array, expected_unique_array):
 
     # Assert
     np.testing.assert_array_almost_equal(unique_array, expected_unique_array)
+
+
+def test_pairing_function():
+    # Arrange
+    input_array = np.array(
+        [
+            [0, 0],
+            [0, 1],
+            [1, 0],
+            [1, 1],
+            [11, 1],
+            [1, 11],
+            [129, 82],
+            [82, 129],
+            [0, 2047],
+            [2047, 0],
+            [2047, 2047],
+        ]
+    )
+    expected_paired_array = np.array(
+        [
+            0,
+            1,
+            1048576,
+            1048577,
+            11534337,
+            1048587,
+            135266386,
+            85983361,
+            2047,
+            2146435072,
+            2146437119,
+        ]
+    )
+
+    # Act
+    paired_array = opt.pairing_function(input_array)
+
+    # Assert
+    np.testing.assert_array_almost_equal(paired_array, expected_paired_array)
+
+
+def test_inverse_pairing_function():
+    # Arrange
+    paired_array = np.array(
+        [
+            0,
+            1,
+            1048576,
+            1048577,
+            11534337,
+            1048587,
+            135266386,
+            85983361,
+            2047,
+            2146435072,
+            2146437119,
+        ]
+    )
+    expected_array = np.array(
+        [
+            [0, 0],
+            [0, 1],
+            [1, 0],
+            [1, 1],
+            [11, 1],
+            [1, 11],
+            [129, 82],
+            [82, 129],
+            [0, 2047],
+            [2047, 0],
+            [2047, 2047],
+        ]
+    )
+
+    # Act
+    array = opt.inverse_pairing_function(paired_array)
+
+    # Assert
+    np.testing.assert_array_almost_equal(array, expected_array)

--- a/tests/unit/vis/_vis_utils/_ms/test_optimised_functions.py
+++ b/tests/unit/vis/_vis_utils/_ms/test_optimised_functions.py
@@ -47,7 +47,7 @@ import xradio.vis._vis_utils._ms.optimised_functions as opt
                 ]
             ),
             np.array([1]),
-        )
+        ),
     ],
 )
 def test_unique_1d(input_array, expected_unique_array):
@@ -56,4 +56,3 @@ def test_unique_1d(input_array, expected_unique_array):
 
     # Assert
     np.testing.assert_array_almost_equal(unique_array, expected_unique_array)
-


### PR DESCRIPTION
The function to get (unique) baselines has been optimised, reducing the computation time from 45s to 0.8s for a 71G LOFAR MeasurementSet. In addition, the function now returns a 2D array of antenna pairs, representing baselines, instead of using strings. The pairing functions used in this function have been added with tests, and a new function has been added to get baseline indices, which is also an optimisation. A function has also been added to get unique values of 1D arrays, which is around 3x faster on average relative the the NumPy method.