### PR TITLE
120 fix writing of casa images

### DIFF
--- a/src/xradio/image/_util/_casacore/common.py
+++ b/src/xradio/image/_util/_casacore/common.py
@@ -30,10 +30,20 @@ def _open_image_rw(
 
 @contextmanager
 def _create_new_image(
-    outfile: str, shape: List[int], mask="", value=np.float32(0.0)
+    outfile: str, shape: List[int], mask="", value="default"
 ) -> Generator[images.image, None, None]:
+#def _create_new_image(
+#    outfile: str, shape: List[int], mask=""
+#) -> Generator[images.image, None, None]:
     # new image will be opened rw
-    image = images.image(outfile, maskname=mask, shape=shape, values=value)
+    # the crux of the issue here seems to be that python has no single
+    # precision floating point value, but we need single precision for
+    # most images. The image constructor gets that right if values isn't
+    # suppliked. Hence two calls with values not present and values present
+    if value == "default":
+        image = images.image(outfile, maskname=mask, shape=shape)
+    else:
+        image = images.image(outfile, maskname=mask, shape=shape, values=value)
     try:
         yield image
     finally:

--- a/src/xradio/image/_util/_casacore/common.py
+++ b/src/xradio/image/_util/_casacore/common.py
@@ -32,9 +32,6 @@ def _open_image_rw(
 def _create_new_image(
     outfile: str, shape: List[int], mask="", value="default"
 ) -> Generator[images.image, None, None]:
-#def _create_new_image(
-#    outfile: str, shape: List[int], mask=""
-#) -> Generator[images.image, None, None]:
     # new image will be opened rw
     # the crux of the issue here seems to be that python has no single
     # precision floating point value, but we need single precision for

--- a/src/xradio/image/_util/_casacore/xds_to_casacore.py
+++ b/src/xradio/image/_util/_casacore/xds_to_casacore.py
@@ -315,6 +315,8 @@ def _write_initial_image(
     for dv in ["sky", "aperture"]:
         if dv in xds.data_vars:
             value = xds[dv][0, 0, 0, 0, 0].values.item()
+            if xds[dv][0, 0, 0, 0, 0].values.dtype == "float32":
+                value = "default"
             break
     # print(type(value))
     image_full_path = os.path.expanduser(imagename)

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -250,7 +250,6 @@ class xds_from_image_test(ImageBase):
         t.flush()
         t.close()
         with open_image_ro(cls._imname) as im:
-            print("dt", im.datatype())
             im.tofits(cls._infits)
         cls._xds = read_image(cls._imname, {"frequency": 5})
         cls._xds_no_sky = read_image(cls._imname, {"frequency": 5}, False, False)
@@ -806,11 +805,9 @@ class casacore_to_xds_to_casacore(xds_from_image_test):
                         (im1.getmask() == im2.getmask()).all(), "Incorrect mask values"
                     )
                     self.assertTrue(
-                        (
-                            im1.datatype() == im2.datatype(),
-                            f"Incorrect round trip pixel type, input {im1.datatype()}, "
-                            + f"output {im2.datatype()}",
-                        )
+                        im1.datatype() == im2.datatype(),
+                        f"Incorrect round trip pixel type, input {im1.name()} {im1.datatype()}, "
+                        + f"output {im2.name()} {im2.datatype()}",
                     )
 
     def test_metadata(self):


### PR DESCRIPTION
root cause seems to be that standard python has no single precision floating point type. So, I had to write a bit of a kludge depending if I want single precision pixels or another type of pixels in the image.