### PR TITLE
145 load image function is creating a dag when opening a imgzarr file

### DIFF
--- a/src/xradio/_utils/zarr/common.py
+++ b/src/xradio/_utils/zarr/common.py
@@ -1,0 +1,68 @@
+import copy
+import xarray as xr
+import zarr
+
+
+def _get_attrs(zarr_obj):
+    """
+    get attributes of zarr obj (groups or arrays)
+    """
+    return {k: v for k, v in zarr_obj.attrs.asdict().items() if not k.startswith("_NC")}
+
+
+def _load_no_dask_zarr(zarr_name, slice_dict={}):
+    """
+    Alternative to xarray open_zarr where the arrays are not Dask Arrays.
+
+    slice_dict: A dictionary of slice objects for which values to read form a dimension.
+                For example silce_dict={'time':slice(0,10)} would select the first 10 elements in the time dimension.
+                If a dim is not specified all values are retruned.
+    return:
+        xarray.Dataset()
+
+    #Should go into general utils.
+    """
+    # Used by xarray to store array labeling info in zarr meta data.
+    DIMENSION_KEY = "_ARRAY_DIMENSIONS"
+
+    # logger = _get_logger()
+    zarr_group = zarr.open_group(store=zarr_name, mode="r")
+    group_attrs = _get_attrs(zarr_group)
+
+    slice_dict_complete = copy.deepcopy(slice_dict)
+    coords = {}
+    xds = xr.Dataset()
+    for var_name, var in zarr_group.arrays():
+        var_attrs = _get_attrs(var)
+
+        for dim in var_attrs[DIMENSION_KEY]:
+            if dim not in slice_dict_complete:
+                slice_dict_complete[dim] = slice(None)  # No slicing.
+
+        if (var_attrs[DIMENSION_KEY][0] == var_name) and (
+            len(var_attrs[DIMENSION_KEY]) == 1
+        ):
+            coord = var[
+                slice_dict_complete[var_attrs[DIMENSION_KEY][0]]
+            ]  # Dimension coordinates.
+            del var_attrs["_ARRAY_DIMENSIONS"]
+            xds = xds.assign_coords({var_name: coord})
+            xds[var_name].attrs = var_attrs
+        else:
+            # Construct slicing
+            slicing_list = []
+            for dim in var_attrs[DIMENSION_KEY]:
+                slicing_list.append(slice_dict_complete[dim])
+            slicing_tuple = tuple(slicing_list)
+            xds[var_name] = xr.DataArray(
+                var[slicing_tuple], dims=var_attrs[DIMENSION_KEY]
+            )
+
+            if "coordinates" in var_attrs:
+                del var_attrs["coordinates"]
+            del var_attrs["_ARRAY_DIMENSIONS"]
+            xds[var_name].attrs = var_attrs
+
+    xds.attrs = group_attrs
+
+    return xds

--- a/src/xradio/image/_util/zarr.py
+++ b/src/xradio/image/_util/zarr.py
@@ -1,6 +1,9 @@
 from ._zarr.xds_to_zarr import _write_zarr
 from ._zarr.xds_from_zarr import _read_zarr
+import numpy as np
+import os
 import xarray as xr
+from ..._utils.zarr.common import _load_no_dask_zarr
 
 
 def _xds_to_zarr(xds: xr.Dataset, zarr_store: str):
@@ -19,3 +22,29 @@ def _xds_from_zarr(
     #    what coordinates should be returned as
     #    "numpy": numpy arrays
     return _read_zarr(zarr_store, output, selection)
+
+
+def _load_image_from_zarr_no_dask(zarr_file: str, selection: dict) -> xr.Dataset:
+    image_xds = _load_no_dask_zarr(zarr_file, selection)
+    for h in ["HISTORY", "_attrs_xds_history"]:
+        history = os.sep.join([zarr_file, h])
+        if os.path.isdir(history):
+            image_xds.attrs["history"] = _load_no_dask_zarr(history)
+            break
+    _iter_dict(image_xds.attrs)
+    return image_xds
+
+
+def _iter_dict(d: dict) -> None:
+    for k, v in d.items():
+        if isinstance(v, dict):
+            keys = v.keys()
+            if (
+                len(keys) == 3
+                and "_dtype" in keys
+                and "_type" in keys
+                and "_value" in keys
+            ):
+                d[k] = np.array(v["_value"], dtype=v["_dtype"])
+            else:
+                _iter_dict(v)

--- a/src/xradio/vis/load_processing_set.py
+++ b/src/xradio/vis/load_processing_set.py
@@ -3,16 +3,18 @@ import zarr
 import copy
 import os
 from ._processing_set import processing_set
+from .._utils.zarr.common import _load_no_dask_zarr
 
 DIMENSION_KEY = "_ARRAY_DIMENSIONS"  # Used by xarray to store array labeling info in zarr meta data.
 # from xradio._utils._logger import _get_logger
 
-
+"""
 def _get_attrs(zarr_obj):
-    """
+    ""
     get attributes of zarr obj (groups or arrays)
-    """
+    ""
     return {k: v for k, v in zarr_obj.attrs.asdict().items() if not k.startswith("_NC")}
+"""
 
 
 def _load_ms_xds(
@@ -91,9 +93,9 @@ def _load_ms_xds_core(ms_xds_name, slice_dict):
 
     return ms_xds
 
-
+"""
 def _load_no_dask_zarr(zarr_name, slice_dict={}):
-    """
+    ""
     Alternative to xarray open_zarr where the arrays are not Dask Arrays.
 
     slice_dict: A dictionary of slice objects for which values to read form a dimension.
@@ -103,7 +105,7 @@ def _load_no_dask_zarr(zarr_name, slice_dict={}):
         xarray.Dataset()
 
     #Should go into general utils.
-    """
+    ""
 
     # logger = _get_logger()
     zarr_group = zarr.open_group(store=zarr_name, mode="r")
@@ -146,7 +148,7 @@ def _load_no_dask_zarr(zarr_name, slice_dict={}):
     xds.attrs = group_attrs
 
     return xds
-
+    """
 
 def load_processing_set(ps_name, sel_parms):
     """

--- a/src/xradio/vis/load_processing_set.py
+++ b/src/xradio/vis/load_processing_set.py
@@ -5,16 +5,7 @@ import os
 from ._processing_set import processing_set
 from .._utils.zarr.common import _load_no_dask_zarr
 
-DIMENSION_KEY = "_ARRAY_DIMENSIONS"  # Used by xarray to store array labeling info in zarr meta data.
 # from xradio._utils._logger import _get_logger
-
-"""
-def _get_attrs(zarr_obj):
-    ""
-    get attributes of zarr obj (groups or arrays)
-    ""
-    return {k: v for k, v in zarr_obj.attrs.asdict().items() if not k.startswith("_NC")}
-"""
 
 
 def _load_ms_xds(
@@ -93,62 +84,6 @@ def _load_ms_xds_core(ms_xds_name, slice_dict):
 
     return ms_xds
 
-"""
-def _load_no_dask_zarr(zarr_name, slice_dict={}):
-    ""
-    Alternative to xarray open_zarr where the arrays are not Dask Arrays.
-
-    slice_dict: A dictionary of slice objects for which values to read form a dimension.
-                For example silce_dict={'time':slice(0,10)} would select the first 10 elements in the time dimension.
-                If a dim is not specified all values are retruned.
-    return:
-        xarray.Dataset()
-
-    #Should go into general utils.
-    ""
-
-    # logger = _get_logger()
-    zarr_group = zarr.open_group(store=zarr_name, mode="r")
-    group_attrs = _get_attrs(zarr_group)
-
-    slice_dict_complete = copy.deepcopy(slice_dict)
-    coords = {}
-    xds = xr.Dataset()
-    for var_name, var in zarr_group.arrays():
-        var_attrs = _get_attrs(var)
-
-        for dim in var_attrs[DIMENSION_KEY]:
-            if dim not in slice_dict_complete:
-                slice_dict_complete[dim] = slice(None)  # No slicing.
-
-        if (var_attrs[DIMENSION_KEY][0] == var_name) and (
-            len(var_attrs[DIMENSION_KEY]) == 1
-        ):
-            coord = var[
-                slice_dict_complete[var_attrs[DIMENSION_KEY][0]]
-            ]  # Dimension coordinates.
-            del var_attrs["_ARRAY_DIMENSIONS"]
-            xds = xds.assign_coords({var_name: coord})
-            xds[var_name].attrs = var_attrs
-        else:
-            # Construct slicing
-            slicing_list = []
-            for dim in var_attrs[DIMENSION_KEY]:
-                slicing_list.append(slice_dict_complete[dim])
-            slicing_tuple = tuple(slicing_list)
-            xds[var_name] = xr.DataArray(
-                var[slicing_tuple], dims=var_attrs[DIMENSION_KEY]
-            )
-
-            if "coordinates" in var_attrs:
-                del var_attrs["coordinates"]
-            del var_attrs["_ARRAY_DIMENSIONS"]
-            xds[var_name].attrs = var_attrs
-
-    xds.attrs = group_attrs
-
-    return xds
-    """
 
 def load_processing_set(ps_name, sel_parms):
     """

--- a/src/xradio/vis/load_processing_set.py
+++ b/src/xradio/vis/load_processing_set.py
@@ -159,6 +159,7 @@ def load_processing_set(ps_name, sel_parms):
         ps[name_ms_xds] = _load_ms_xds(ps_name, name_ms_xds, ms_xds_sel_parms)[0]
     return ps
 
+
 class processing_set_iterator:
 
     def __init__(self, data_selection, input_data_store, input_data=None):
@@ -175,15 +176,15 @@ class processing_set_iterator:
             xds_name = next(self.xds_name_iter)
         except Exception as e:
             raise StopIteration
-        
+
         if self.input_data is None:
             slice_description = self.data_selection[xds_name]
             ps = load_processing_set(
-                    ps_name=self.input_data_store,
-                    sel_parms={xds_name: slice_description},
-                )
+                ps_name=self.input_data_store,
+                sel_parms={xds_name: slice_description},
+            )
             xds = ps.get(0)
         else:
-            xds = self.input_data[xds_name] #In memory
+            xds = self.input_data[xds_name]  # In memory
 
         return xds

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -565,6 +565,8 @@ class xds_from_image_test(ImageBase):
                         f"got wrong data type, got {xds['sky'].dtype}, "
                         + f"expected {im.datatype()}",
                     )
+            print(xds.attrs["direction"])
+
             self.assertEqual(xds.sky.shape, (1, 1, 4, 8, 12), "Wrong block shape")
             big_xds = self._xds if i == 0 else self._xds_no_sky
             self.assertTrue(


### PR DESCRIPTION
Move_load_no_dask_zarr() and helper  _get_attrs() from vis/load_processing_set.py  to _utils/zarr/common.py 
load_image() now uses _load_no_dask_zarr() wrapped in image specific code (read history xds attr, decode encoded dicts back to numpy arrays, etc) to read data and avoids creating a DAG.