### PR TITLE
Include model column in MSv2 to MSv4 conversion

### DIFF
--- a/src/xradio/vis/_vis_utils/_ms/msv2_to_msv4_meta.py
+++ b/src/xradio/vis/_vis_utils/_ms/msv2_to_msv4_meta.py
@@ -1,6 +1,7 @@
 col_to_data_variable_names = {
     "FLOAT_DATA": "SPECTRUM",
     "DATA": "VISIBILITY",
+    "MODEL_DATA": "VIS_MODEL",
     "CORRECTED_DATA": "VISIBILITY_CORRECTED",
     "WEIGHT_SPECTRUM": "WEIGHT",
     "WEIGHT": "WEIGHT",
@@ -12,6 +13,7 @@ col_to_data_variable_names = {
 col_dims = {
     "DATA": ("time", "baseline_id", "frequency", "polarization"),
     "CORRECTED_DATA": ("time", "baseline_id", "frequency", "polarization"),
+    "MODEL_DATA": ("time", "baseline_id", "frequency", "polarization"),
     "WEIGHT_SPECTRUM": ("time", "baseline_id", "frequency", "polarization"),
     "WEIGHT": ("time", "baseline_id", "frequency", "polarization"),
     "FLAG": ("time", "baseline_id", "frequency", "polarization"),


### PR DESCRIPTION
**Background:**

The model data is not being included in the `convert_msv2_to_processing_set`. PR includes the `MODEL_DATA` column so it can be used later