### PR TITLE
Convert docstrings to numpy style (in vis)

### DIFF
--- a/src/xradio/vis/_vis_utils/_ms/_tables/load.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/load.py
@@ -17,16 +17,29 @@ def load_col_chunk(
     """
     Loads a slice of a col (using casacore getcol(slice))
 
-    :param tb_tool: a table/TaQL query open and being used to load columns
-    :param col: colum to load
-    :param cshape: shape of the resulting col data chunk
-    :param tidxs: time axis indices
-    :param bidxs: baseline axis indices
-    :param didxs: (effective) data indices, excluding missing baselines
-    :param d1: indices to load on dimension 1 (None=all, pols or chans)
-    :param d2: indices to load on dimension 2 (None=all, pols)
+    Parameters
+    ----------
+    tb_tool : tables.table
+        a table/TaQL query open and being used to load columns
+    col : str
+        colum to load
+    cshape : Tuple[int]
+        shape of the resulting col data chunk
+    tidxs : np.ndarray
+        time axis indices
+    bidxs : np.ndarray
+        baseline axis indices
+    didxs : np.ndarray
+        effective) data indices, excluding missing baselines
+    d1 : Tuple[int, int]
+        indices to load on dimension 1 (None=all, pols or chans)
+    d2 : Tuple[int, int]
+        indices to load on dimension 2 (None=all, pols)
 
-    :return: data array loaded directly with casacore getcol/getcolslice
+    Returns
+    -------
+    np.ndarray
+        data array loaded directly with casacore getcol/getcolslice
     """
 
     if (len(cshape) == 2) or (col == "UVW"):

--- a/src/xradio/vis/_vis_utils/_ms/_tables/load_main_table.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/load_main_table.py
@@ -284,7 +284,9 @@ def get_chunk_times(
     return utimes, times
 
 
-def get_chunk_baselines(tb_tool: tables.table, chunk: Dict[str, slice]) -> Tuple[np.ndarray, Tuple[int, int]]:
+def get_chunk_baselines(
+    tb_tool: tables.table, chunk: Dict[str, slice]
+) -> Tuple[np.ndarray, Tuple[int, int]]:
     """
     Produces the basline col/axis related values for a chunk: an array of
     baselines and the start/stop baseline indices.

--- a/src/xradio/vis/_vis_utils/_ms/_tables/load_main_table.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/load_main_table.py
@@ -29,12 +29,21 @@ def load_expanded_main_table_chunk(
     Load a chunk of data from main table into memory, with expanded
     dims: (time, baseline, freq, pols)
 
-    :param infile: Input MS path
-    :param ddi: DDI to load chunk from
-    :param chunk: specification of chunk to load
-    :param ignore_msv2_cols: cols that should not be loaded (deprecated MSv2 or similar)
+    Parameters
+    ----------
+    infile : str
+        Input MS path
+    ddi : int
+        DDI to load chunk from
+    chunk : Dict[str, slice]
+        specification of chunk to load
+    ignore_msv2_cols : Union[list, None] (Default value = None)
+        cols that should not be loaded (deprecated MSv2 or similar)
 
-    :return: Xarray datasets with chunk of visibility data, one per DDI (spw_id, pol_setup_id) pair
+    Returns
+    -------
+    xr.Dataset
+        Xarray datasets with chunk of visibility data, one per DDI (spw_id, pol_setup_id) pair
     """
 
     taql_where = f"where DATA_DESC_ID = {ddi}"
@@ -64,16 +73,24 @@ def load_expanded_ddi_chunk(
     xr.Dataset from a DII once the table and initial query(ies) have
     been opened successfully.
 
-    :param infile: Input MS path
-    :param tb_tool: table query contrained to one DDI and chunk time
-    range
-    :param taql_pre: TaQL query used for tb_tool, with some
-    pre-selection of rows and columns
-    :param chunk: specification of data chunk to load
-    :param ignore_msv2_cols: propagated from calling funtions
+    Parameters
+    ----------
+    infile : str
+        Input MS path
+    tb_tool : tables.table
+        table query contrained to one DDI and chunk time range
+    taql_pre : str
+        TaQL query used for tb_tool, with some pre-selection of rows and columns
+    chunk : Dict[str, slice]
+        specification of data chunk to load
+    ignore_msv2_cols : Union[list, None] (Default value = None)
+        propagated from calling funtions
 
-    :return: An Xarray datasets with data variables as plain numpy
-    arrays loaded directly from the MS columns
+    Returns
+    -------
+    xr.Dataset
+        An Xarray dataset with data variables as plain numpy
+        arrays loaded directly from the MS columns
     """
 
     # read the specified chunk of data, figure out indices and lens
@@ -124,16 +141,30 @@ def load_ddi_cols_chunk(
     """
     For a given chunk and DDI, load all the MSv2 columns
 
-    :param ctlen: length of the time axis/dim of the chunk
-    :param cblen: length of the baseline axis of the chunk
-    :param tidxs: time axis indices
-    :param bidxs: baseline axis indices
-    :param didxs: (effective) data indices, excluding missing baselines
-    :param tb_tool: a table/TaQL query open and being used to load columns
-    :param chunk: data chunk specification
-    :param ignore_msv2_cols: propagated from calling funtions
+    Parameters
+    ----------
+    ctlen : int
+        length of the time axis/dim of the chunk
+    cblen : int
+        length of the baseline axis of the chunk
+    tidxs : np.ndarray
+        time axis indices
+    bidxs : np.ndarray
+        baseline axis indices
+    didxs : np.ndarray
+        (effective) data indices, excluding missing baselines
+    tb_tool : tables.table
+        a table/TaQL query open and being used to load columns
+    chunk : Dict[str, slice]
+        data chunk specification
+    ignore_msv2_cols : Union[list, None] (Default value = None)
+        propagated from calling funtions
 
-    :return: columns loaded into memory as np arrays
+    Returns
+    -------
+    Dict[str, np.ndarray]
+        columns loaded into memory as np arrays
+
     """
     cols = tb_tool.colnames()
 
@@ -194,16 +225,23 @@ def load_ddi_cols_chunk(
 
 def get_chunk_times(
     taql_pre: str, chunk: Dict[str, slice]
-) -> Tuple[np.ndarray, Tuple[int, int], int]:
+) -> Tuple[np.ndarray, Tuple[int, int]]:
     """
     Produces time col/axis related values for a chunk: unique times,
     start/stop times.
 
-    :param chunk: specification of data chunk to load
-    :param taql_pre: TaQL query used for tb_tool, with some pre-selection
-    of rows and columns.
+    Parameters
+    ----------
+    taql_pre : str
+        TaQL query used for tb_tool, with some pre-selection
+        of rows and columns.
+    chunk : Dict[str, slice]
+        specification of data chunk to load
 
-    :return: array of unique times + (firsr, last) time in the chunk
+    Returns
+    -------
+    Tuple[np.ndarray, Tuple[int, int]]
+        array of unique times + (firsr, last) time in the chunk
     """
 
     taql_utimes = f"select DISTINCT TIME from $mtable {taql_pre}"
@@ -246,15 +284,22 @@ def get_chunk_times(
     return utimes, times
 
 
-def get_chunk_baselines(tb_tool, chunk) -> Tuple[np.ndarray, Tuple[int, int], int]:
+def get_chunk_baselines(tb_tool: tables.table, chunk: Dict[str, slice]) -> Tuple[np.ndarray, Tuple[int, int]]:
     """
-    Produces the basline col/axis related values for a chunk: an array
-    of baselines and the start/stop baseline indices.
+    Produces the basline col/axis related values for a chunk: an array of
+    baselines and the start/stop baseline indices.
 
-    :param tb_tool: table/query opened with prev selections (time)
-    :param chunk: specification of data chunk to load
+    Parameters
+    ----------
+    tb_tool : tables.table
+        table/query opened with prev selections (time)
+    chunk : Dict[str, slice]
+        specification of data chunk to load
 
-    :return: array of baselines + (first, last) baseline in the chunk
+    Returns
+    -------
+    Tuple[np.ndarray, Tuple[int, int]]
+        array of baselines + (first, last) baseline in the chunk
     """
     baselines = get_baselines(tb_tool)
 
@@ -274,22 +319,35 @@ def get_chunk_data_indices(
     times: Tuple[int, int],
     baselines: np.ndarray,
     blines: Tuple[int, int],
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, str]:
     """
-    Produces indices to pass to the casacore getcol(slice) functions
-    to load the chunk of data. tidxs (time), bidxs (baseline),
-    didxs (effective data indices, considering present/absent
-    baselines).
+    Produces indices to pass to the casacore getcol(slice) functions to load
+    the chunk of data. tidxs (time), bidxs (baseline), didxs (effective data
+    indices, considering present/absent baselines).
 
     Time selection is added on top of that.
 
-    :param utimes: array of times in the chunk
-    :param times: start, stop time indices
-    :param baselines: array of baselines inthe chunk
-    :param blines: start, stop baseline indices
+    Parameters
+    ----------
+    taql_pre : str
+        TaQL query constraints to prepend/inject
+    chunk : Dict[str, slice]
+        specification of data chunk
+    utimes : np.ndarray
+        array of times in the chunk
+    times : Tuple[int, int]
+        start, stop time indices
+    baselines : np.ndarray
+        array of baselines inthe chunk
+    blines : Tuple[int, int]
+        start, stop baseline indices
 
-    :return: indices along the time, baseline and data (time/baseline)
-    axes + the full where... defined for this chunk
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray, np.ndarray]
+        indices along the time, baseline and data (time/baseline)
+        axes + the full where... string defined for this chunk
+
     """
 
     taql_time = f"TIME BETWEEN {utimes[times[0]]} AND {utimes[times[1]]}"
@@ -333,14 +391,25 @@ def get_col_1d_pols(
     indices for the last dimension (either pol or freq).
     It also produces the adequate dimension names.
 
-    :param cell_shape: shape of the column
-    :param dims: full list of dataset dimensions
-    :param chan_cnt: number of channels
-    :param pol_cnt: number of pols
-    :param chunk: data chunk specification
+    Parameters
+    ----------
+    cell_shape : Tuple[int]
+        shape of the column
+    dims : List[str]
+        full list of dataset dimensions
+    chan_cnt : int
+        number of channels
+    pol_cnt : int
+        number of pols
+    chunk : Dict[str, slice]
+        data chunk specification
 
-    :return: first and last pol/freq index of the chunk, and its
-    dimension name
+    Returns
+    -------
+    Tuple[Tuple[int, int], List[str]]
+        first and last pol/freq index of the chunk, and its
+        dimension names
+
     """
     if cell_shape == chan_cnt:
         # chan/freq
@@ -379,13 +448,23 @@ def get_col_2d_chans_pols(
     The dimension names can be assumed to be the full list of dims in
     visibilities (time, baseline, freq, pol).
 
-    :param cell_shape: shape of the column
-    :param chan_cnt: number of channels
-    :param pol_cnt: number of pols
-    :param chunk: data chunk specification
+    Parameters
+    ----------
+    cell_shape : Tuple[int]
+        shape of the column
+    chan_cnt : int
+        number of channels
+    pol_cnt : int
+        number of pols
+    chunk : Dict[str, slice]
+        data chunk specification
 
-    :return: first and last index for freq (channel) and pol axes of
-    the chunk
+    Returns
+    -------
+    Tuple[Tuple[int, int], Tuple[int, int]]
+        first and last index for freq (channel) and pol axes of
+        the chunk
+
     """
     if "freq" in chunk:
         chans = (

--- a/src/xradio/vis/_vis_utils/_ms/_tables/read.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read.py
@@ -2,7 +2,7 @@ import graphviper.utils.logger as logger
 import os
 from pathlib import Path
 import re
-from typing import Any, List, Dict, Tuple, Union
+from typing import Any, Callable, Dict, List, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -21,7 +21,7 @@ def table_exists(path: str) -> bool:
     return tables.tableexists(path)
 
 
-def convert_casacore_time(rawtimes: np.ndarray, convert_to_datetime=True) -> np.ndarray:
+def convert_casacore_time(rawtimes: np.ndarray, convert_to_datetime: bool = True) -> np.ndarray:
     """
     Read time columns to datetime format
     pandas datetimes are referenced against a 0 of 1970-01-01
@@ -29,8 +29,17 @@ def convert_casacore_time(rawtimes: np.ndarray, convert_to_datetime=True) -> np.
 
     This requires a correction of 3506716800 seconds which is hardcoded to save time
 
-    :param rawtimes: times in casacore ref
-    :return: times converted to pandas reference
+    Parameters
+    ----------
+    rawtimes : np.ndarray
+        times in casacore ref
+    convert_to_datetime : bool (Default value = True)
+        whether to produce pandas style datetime
+
+    Returns
+    -------
+    np.ndarray
+        times converted to pandas reference
     """
 
     if convert_to_datetime:
@@ -45,11 +54,19 @@ def convert_casacore_time(rawtimes: np.ndarray, convert_to_datetime=True) -> np.
 
 
 def convert_mjd_time(rawtimes: np.ndarray) -> np.ndarray:
-    """Different time conversion needed for the MJD col of EPHEM{i}_*.tab
+    """
+    Different time conversion needed for the MJD col of EPHEM{i}_*.tab
     files (only, as far as I've seen)
 
-    :param rawtimes: MJD times for example from the MJD col of ephemerides tables
-    :return: times converted to pandas reference and datetime type
+    Parameters
+    ----------
+    rawtimes : np.ndarray
+        MJD times for example from the MJD col of ephemerides tables
+
+    Returns
+    -------
+    np.ndarray
+        times converted to pandas reference and datetime type
     """
     return pd.to_datetime(
         rawtimes * SECS_IN_DAY - CASACORE_TO_PD_TIME_CORRECTION, unit="s"
@@ -58,7 +75,17 @@ def convert_mjd_time(rawtimes: np.ndarray) -> np.ndarray:
 
 def extract_table_attributes(infile: str) -> Dict[str, Dict]:
     """
-    return a dictionary of table attributes created from MS keywords and column descriptions
+    Return a dictionary of table attributes created from MS keywords and column descriptions
+
+    Parameters
+    ----------
+    infile : str
+        table file path
+
+    Returns
+    -------
+    Dict[str, Dict]
+        table attributes as a dictionary
     """
     with open_table_ro(infile) as tb_tool:
         kwd = tb_tool.getkeywords()
@@ -79,9 +106,17 @@ def add_units_measures(
     """
     Add attributes with units and measure metainfo to the variables passed in the input dictionary
 
-    :param mvars: data variables where to populate units
-    :param cc_attrs: dictionary with casacore table attributes (from extract_table_attributes)
-    :return: variables with units added in their attributes
+    Parameters
+    ----------
+    mvars : Dict[str, xr.DataArray]
+        data variables where to populate units
+    cc_attrs : Dict[str, Any]
+        dictionary with casacore table attributes (from extract_table_attributes)
+
+    Returns
+    -------
+    Dict[str, xr.DataArray]
+        variables with units added in their attributes
     """
     col_descrs = cc_attrs["column_descriptions"]
     # TODO: Should probably loop the other way around, over mvars
@@ -128,7 +163,8 @@ def add_units_measures(
 
 
 def make_freq_attrs(spw_xds: xr.Dataset, spw_id: int) -> Dict[str, Any]:
-    """Grab the units/measure metainfo for the xds.freq dimension of a
+    """
+    Grab the units/measure metainfo for the xds.freq dimension of a
     parttion from the SPECTRAL_WINDOW subtable CTDS attributes.
 
     Has to read xds_spw.meas_freq_ref and use it as index in the CTDS
@@ -137,10 +173,17 @@ def make_freq_attrs(spw_xds: xr.Dataset, spw_id: int) -> Dict[str, Any]:
     (then the ref frame from the second will be pulled to
     xds.freq.attrs)
 
-    :param spw_xds: (metainfo) SPECTRAL_WINDOW xds
-    :param spw_id: SPW id of a partition
-    :return: attributes (units/measure) for the freq dim of a partition
+    Parameters
+    ----------
+    spw_xds : xr.Dataset
+        (metainfo) SPECTRAL_WINDOW xds
+    spw_id : int
+        SPW id of a partition
 
+    Returns
+    -------
+    Dict[str, Any]
+        attributes (units/measure) for the freq dim of a partition
     """
     fallback_TabRefTypes = [
         "REST",
@@ -193,6 +236,11 @@ def get_pad_nan(col: np.ndarray) -> np.ndarray:
     ----------
     col : np.ndarray
         data being loaded from a table column
+
+    Returns
+    -------
+    np.ndarray
+        nan ("nan") value for the type of the input column
     """
     # This is causing frequent warnings for integers. Cast of nan to "int nan"
     # produces -2147483648 but also seems to trigger a
@@ -208,15 +256,24 @@ def get_pad_nan(col: np.ndarray) -> np.ndarray:
 
 
 def redimension_ms_subtable(xds: xr.Dataset, subt_name: str) -> xr.Dataset:
-    """Expand a MeasurementSet subtable xds from single dimension (row)
+    """
+    Expand a MeasurementSet subtable xds from single dimension (row)
     to multiple dimensions (such as (source_id, time, spectral_window)
 
     WIP: only works for source, experimenting
 
-    :param xds: dataset to change the dimensions
-    :param subt_name: subtable name (SOURCE, etc.)
-    :return: transformed xds with data dimensions representing the MS subtable key
-    (one dimension for every columns)
+    Parameters
+    ----------
+    xds : xr.Dataset
+        dataset to change the dimensions
+    subt_name : str
+        subtable name (SOURCE, etc.)
+
+    Returns
+    -------
+    xr.Dataset
+        transformed xds with data dimensions representing the MS subtable key
+        (one dimension for every columns)
     """
     subt_key_cols = {
         "DOPPLER": ["doppler_id", "source_id"],
@@ -314,16 +371,25 @@ def read_generic_table(
 
     Parameters
     ----------
-    :param inpath: path to the MS or directory containing the table
-    :param tname: (sub)table name, for example 'SOURCE' for myms.ms/SOURCE
+    inpath : str
+        path to the MS or directory containing the table
+    tname : str
+        (sub)table name, for example 'SOURCE' for myms.ms/SOURCE
+    timecols : Union[List[str], None] (Default value = None)
+        column names to convert to numpy datetime format.
+        leaves times as their original casacore format.
+    ignore : Union[List[str], None] (Default value = None)
+        list of column names to ignore and not try to read.
+    rename_ids : Dict[str, str] (Default value = None)
+        dict with dimension renaming mapping
+    taql_where : str
+         TaQL string to optionally constain the rows/columns to read
+         (Default value = None)
 
-    :param timecols: column names to convert to numpy datetime format.
-    leaves times as their original casacore format.
-    :param ignore: list of column names to ignore and not try to read.
-    :rename_ids: dict with dimension renaming mapping
-    :taql_where: TaQL string to optionally constain the rows/columns to read
-
-    :return: table loaded as XArray dataset
+    Returns
+    -------
+    xr.Dataset
+        table loaded as XArray dataset
     """
     if timecols is None:
         timecols = []
@@ -403,6 +469,22 @@ def load_cols_into_coords_data_vars(
     """
     Produce a set of coordinate xarrays and a set of data variables xarrays
     from the columns of a table.
+
+    Parameters
+    ----------
+    inpath : str
+        input path
+    tb_tool: tables.table
+        tool being used to load data
+    timecols: Union[List[str], None] (Default value = None)
+        list of columns to be considered as TIME-related
+    ignore: Union[List[str], None] (Default value = None)
+        columns to ignore
+
+    Returns
+    -------
+    Tuple[Dict[str, xr.Dataset], Dict[str, xr.Dataset]]
+        coordinates dictionary + variables dictionary
     """
     columns_loader = find_best_col_loader(inpath, tb_tool.nrows())
 
@@ -411,7 +493,7 @@ def load_cols_into_coords_data_vars(
     return mcoords, mvars
 
 
-def find_best_col_loader(inpath: str, nrows: int):
+def find_best_col_loader(inpath: str, nrows: int) -> Callable:
     """
     Simple heuristic: for any tables other than POINTING, use the generic_load_cols
     function that is able to deal with variable size columns. For POINTING (and if it has
@@ -427,10 +509,17 @@ def find_best_col_loader(inpath: str, nrows: int):
     when the table is POINTING. See xradio issue #128 for now this distinction is made
     solely for performance reasons.
 
-    :param inpath: path name of the MS table
-    :param nrows: number of rows found in the table
+    Parameters
+    ----------
+    inpath : str
+        path name of the MS table
+    nrows : int
+        number of rows found in the table
 
-    :return: function best suited to load the data from the columns of this table
+    Returns
+    -------
+    Callable
+        function best suited to load the data from the columns of this table
     """
     # do not give up generic by-row() loading if nrows is (arbitrary) small
     ARBITRARY_MIN_ROWS = 1000
@@ -449,19 +538,29 @@ def load_generic_cols(
     timecols: Union[List[str], None],
     ignore: Union[List[str], None],
 ) -> Tuple[Dict[str, xr.Dataset], Dict[str, xr.Dataset]]:
-    """Loads data for each MS column (loading the data in memory) into Xarray datasets
+    """
+    Loads data for each MS column (loading the data in memory) into Xarray datasets
 
     This function is generic in that it can load variable size array columns. See also
     load_fixed_size_cols() as a simpler and much better performing alternative
     for tables that are large and expected/guaranteed to not have columns with variable
     size cells.
 
-    :param inpath: path name of the MS table
-    :param tb_tool: table to load the columns
-    :param timecols: columns names to convert to datetime format
-    :param ignore: list of column names to skip and not try to load.
+    Parameters
+    ----------
+    inpath : str
+        path name of the MS table
+    tb_tool : tables.table
+        table to load the columns
+    timecols : Union[List[str], None]
+        columns names to convert to datetime format
+    ignore : Union[List[str], None]
+        list of column names to skip and not try to load.
 
-    :return: dict of coordinates and dict of data vars.
+    Returns
+    -------
+    Tuple[Dict[str, xr.Dataset], Dict[str, xr.Dataset]]
+        dict of coordinates and dict of data vars.
     """
 
     col_cells = find_loadable_filled_cols(tb_tool, ignore)
@@ -527,13 +626,21 @@ def load_fixed_size_cols(
     size (even if they are of array type).
     This is performance-critical for the POINTING subtable.
 
-    :param inpath: path name of the MS
-    :param tb_tool: table to red the columns
-    :param timecols: columns names to convert to datetime format
-    :param ignore: list of column names to skip and not try to load.
+    Parameters
+    ----------
+    inpath : str
+        path name of the MS
+    tb_tool : tables.table
+        table to red the columns
+    timecols : Union[List[str], None]
+        columns names to convert to datetime format
+    ignore : Union[List[str], None]
+        list of column names to skip and not try to load.
 
-    :return: dict of coordinates and dict of data vars, ready to construct
-    an xr.Dataset
+    Returns
+    -------
+    Tuple[Dict[str, xr.Dataset], Dict[str, xr.Dataset]]
+        dict of coordinates and dict of data vars, ready to construct an xr.Dataset
     """
 
     loadable_cols = find_loadable_filled_cols(tb_tool, ignore)
@@ -565,16 +672,23 @@ def load_fixed_size_cols(
     return mcoords, mvars
 
 
-def find_loadable_filled_cols(tb_tool: tables.table, ignore: Union[List[str], None]):
+def find_loadable_filled_cols(tb_tool: tables.table, ignore: Union[List[str], None]) -> Dict:
     """
     For a table, finds the columns that are:
     - loadable = not of record type, and not to be ignored
     - filled = the column cells are populated.
 
-    :param tb_tool: table to red the columns
-    :param ignore: list of column names to skip and not try to load.
+    Parameters
+    ----------
+    tb_tool : tables.table
+        table to red the columns
+    ignore : Union[List[str], None]
+        list of column names to skip and not try to load.
 
-    :return: dict of {column name => first cell} for columns that can/should be loaded
+    Returns
+    -------
+    Dict
+        dict of {column name => first cell} for columns that can/should be loaded
     """
 
     colnames = tb_tool.colnames()
@@ -600,8 +714,24 @@ def raw_col_data_to_coords_vars(
     From a raw np array of data (freshly loaded from a table column), prepares either a
     coord or a data_var ready to be added to an xr.Dataset
 
-    :return: whether this column is a 'coord' or a 'data_var', DataArray
-    with column data/coord values ready to be added to the table xds
+    Parameters
+    ----------
+    inpath: str
+        input table path
+    tb_tool: tables.table :
+        table toold being used to load data
+    col: str :
+        column
+    data: np.ndarray :
+        column data
+    timecols: Union[List[str], None]
+        columns to be treated as TIME-related
+
+    Returns
+    -------
+    Tuple[str, xr.DataArray]
+        array type string (whether this column is a 'coord' or a 'data_var') + DataArray
+        with column  data/coord values ready to be added to the table xds
     """
 
     # Almost sure that when TIME is present (in a standard MS subt) it
@@ -669,12 +799,21 @@ def handle_variable_col_issues(
     table (CHAN_WIDTH, EFFECTIVE_BW, etc.).
     Also handle exceptions gracefully when trying to load the rows.
 
-    :param inpath: path name of the MS
-    :param col: column being loaded
-    :param col_cells: {col: cell} values
-    :param trows: rows from a table as loaded by tables.row()
+    Parameters
+    ----------
+    inpath : str
+        path name of the MS
+    col : str
+        column being loaded
+    col_cells : dict
+        col: cell} values
+    trows : tables.tablerow
+        rows from a table as loaded by tables.row()
 
-    :return: array with column values (possibly padded if rows vary in size)
+    Returns
+    -------
+    np.ndarray
+        array with column values (possibly padded if rows vary in size)
     """
 
     # Optional cols known to sometimes have inconsistent values
@@ -713,6 +852,24 @@ def handle_variable_col_issues(
 def read_flat_col_chunk(infile, col, cshape, ridxs, cstart, pstart) -> np.ndarray:
     """
     Extract data chunk for each table col, this is fed to dask.delayed
+
+    Parameters
+    ----------
+    infile :
+
+    col :
+
+    cshape :
+
+    ridxs :
+
+    cstart :
+
+    pstart :
+
+    Returns
+    -------
+    np.ndarray
     """
 
     with open_table_ro(infile) as tb_tool:
@@ -774,6 +931,30 @@ def read_col_chunk(
 ) -> np.ndarray:
     """
     Function to perform delayed reads from table columns.
+
+    Parameters
+    ----------
+    infile : str
+
+    ts_taql : str
+
+    col : str
+
+    cshape : Tuple[int]
+
+    tidxs : np.ndarray
+
+    bidxs : np.ndarray
+
+    didxs : np.ndarray
+
+    d1: Tuple[int, int]
+
+    d2: Tuple[int, int]
+
+    Returns
+    -------
+    np.ndarray
     """
     # TODO: consider calling load_col_chunk() from inside the withs
     # for read_delayed_pointing_table and read_expanded_main_table
@@ -795,15 +976,31 @@ def read_col_chunk(
 
 
 def read_col_conversion(
-    tb_tool,
+    tb_tool: tables.table,
     col: str,
     cshape: Tuple[int],
     tidxs: np.ndarray,
     bidxs: np.ndarray,
-):
+) -> np.ndarray:
     """
     Function to perform delayed reads from table columns when converting
     (no need for didxs)
+
+    Parameters
+    ----------
+    tb_tool : tables.table
+
+    col : str
+
+    cshape : Tuple[int]
+
+    tidxs : np.ndarray
+
+    bidxs : np.ndarray
+
+    Returns
+    -------
+    np.ndarray
     """
 
     # Workaround for https://github.com/casacore/python-casacore/issues/130

--- a/src/xradio/vis/_vis_utils/_ms/_tables/read.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read.py
@@ -21,7 +21,9 @@ def table_exists(path: str) -> bool:
     return tables.tableexists(path)
 
 
-def convert_casacore_time(rawtimes: np.ndarray, convert_to_datetime: bool = True) -> np.ndarray:
+def convert_casacore_time(
+    rawtimes: np.ndarray, convert_to_datetime: bool = True
+) -> np.ndarray:
     """
     Read time columns to datetime format
     pandas datetimes are referenced against a 0 of 1970-01-01
@@ -672,7 +674,9 @@ def load_fixed_size_cols(
     return mcoords, mvars
 
 
-def find_loadable_filled_cols(tb_tool: tables.table, ignore: Union[List[str], None]) -> Dict:
+def find_loadable_filled_cols(
+    tb_tool: tables.table, ignore: Union[List[str], None]
+) -> Dict:
     """
     For a table, finds the columns that are:
     - loadable = not of record type, and not to be ignored
@@ -828,9 +832,11 @@ def handle_variable_col_issues(
         data = np.stack(
             [
                 np.pad(
-                    row[col]
-                    if len(row[col]) > 0
-                    else np.array(row[col]).reshape(np.arange(len(mshape)) * 0),
+                    (
+                        row[col]
+                        if len(row[col]) > 0
+                        else np.array(row[col]).reshape(np.arange(len(mshape)) * 0)
+                    ),
                     [(0, ss) for ss in mshape - np.array(row[col]).shape],
                     "constant",
                     constant_values=pad_nan,

--- a/src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
@@ -38,14 +38,22 @@ rename_msv2_cols = {
 
 
 def rename_vars(mvars: Dict[str, xr.DataArray]) -> Dict[str, xr.DataArray]:
-    """Apply rename rules. Also preserve ordering of data_vars
+    """
+    Apply rename rules. Also preserve ordering of data_vars
 
     Note: not using xr.DataArray.rename because we have optional
     column renames and rename complains if some of the names passed
     are not present in the dataset
 
-    :param mvars: dictionary of data_vars to be used to create an xr.Dataset
-    :return: similar dictionary after applying MSv2 => MSv3/ngCASA renaming rules
+    Parameters
+    ----------
+    mvars : Dict[str, xr.DataArray]
+        dictionary of data_vars to be used to create an xr.Dataset
+
+    Returns
+    -------
+    Dict[str, xr.DataArray]
+        similar dictionary after applying MSv2 => MSv3/ngCASA renaming rules
     """
     renamed = {
         rename_msv2_cols[name] if name in rename_msv2_cols else name: var
@@ -62,8 +70,16 @@ def redim_id_data_vars(mvars: Dict[str, xr.DataArray]) -> Dict[str, xr.DataArray
     The antenna id data vars:
      From MS (antenna1_id(time, baseline), antenna2_id(time,baseline)
      To cds (baseline_ant1_id(baseline), baseline_ant2_id(baseline)
-    :param mvars: data variables being prepared for a partition xds
-    :return: data variables with the ant id ones modified to cds type
+
+    Parameters
+    ----------
+    mvars : Dict[str, xr.DataArray]
+        data variables being prepared for a partition xds
+
+    Returns
+    -------
+    Dict[str, xr.DataArray]
+        data variables with the ant id ones modified to cds type
     """
     # Vars to drop baseline dim
     var_names = [
@@ -85,12 +101,21 @@ def redim_id_data_vars(mvars: Dict[str, xr.DataArray]) -> Dict[str, xr.DataArray
 
 
 def get_partition_ids(mtable: tables.table, taql_where: str) -> Dict:
-    """Get some of the partition IDs that we have to retrieve from some
+    """
+    Get some of the partition IDs that we have to retrieve from some
     of the top level ID/sorting cols of the main table of the MS.
 
-    :param mtable: MS main table
-    :param taql_where: where part that defines the partition in TaQL
-    :return: ids of array, observation, and processor
+    Parameters
+    ----------
+    mtable : tables.table
+        MS main table
+    taql_where : str
+        where part that defines the partition in TaQL
+
+    Returns
+    -------
+    Dict
+        ids of array, observation, and processor
     """
 
     taql_ids = f"select DISTINCT ARRAY_ID, OBSERVATION_ID, PROCESSOR_ID from $mtable {taql_where}"
@@ -130,6 +155,23 @@ def read_expanded_main_table(
     This is the expanded version (time, baseline) dims.
 
     Chunk tuple: (time, baseline, freq, pol)
+
+    Parameters
+    ----------
+    infile : str
+
+    ddi : int  (Default value = 0)
+
+    scan_state : Union[Tuple[int, int], None] (Default value = None)
+
+    ignore_msv2_cols: Union[list, None] (Default value = None)
+
+    chunks: Tuple[int, ...] (Default value = (400, 200, 100, 2))
+
+
+    Returns
+    -------
+    Tuple[xr.Dataset, Dict[str, Any], Dict[str, Any]]
     """
     if ignore_msv2_cols is None:
         ignore_msv2_cols = []
@@ -175,6 +217,23 @@ def read_main_table_chunks(
     """
     Iterates through the time,baseline chunks and reads slices from
     all the data columns.
+
+    Parameters
+    ----------
+    infile : str
+
+    tb_tool : tables.table
+
+    taql_where : str
+
+    ignore_msv2_cols : Union[list, None] (Default value = None)
+
+    chunks: Tuple[int, ...] (Default value = (400, 200, 100, 2))
+
+
+    Returns
+    -------
+    Tuple[xr.Dataset, Dict[str, Any]]
     """
     baselines = get_baselines(tb_tool)
 
@@ -279,16 +338,21 @@ def get_utimes_tol(mtable: tables.table, taql_where: str) -> Tuple[np.ndarray, f
 
 
 def get_baselines(tb_tool: tables.table) -> np.ndarray:
-    """Gets the unique baselines from antenna 1 and antenna 2 ids.
+    """
+    Gets the unique baselines from antenna 1 and antenna 2 ids.
 
     Uses a pairing function and inverse pairing function to decrease the
     computation time of finding unique values.
 
-    Args:
-        tb_tool (tables.table): MeasurementSet table to get the antenna ids.
+    Parameters
+    ----------
+    tb_tool : tables.table
+        MeasurementSet table to get the antenna ids.
 
-    Returns:
-        unique_baselines (np.ndarray): a 2D array of unique antenna pairs
+    Returns
+    -------
+    unique_baselines : np.ndarray
+        a 2D array of unique antenna pairs
         (baselines) from the MeasurementSet table provided.
     """
     ant1, ant2 = tb_tool.getcol("ANTENNA1", 0, -1), tb_tool.getcol("ANTENNA2", 0, -1)
@@ -312,19 +376,23 @@ def get_baselines(tb_tool: tables.table) -> np.ndarray:
 def get_baseline_indices(
     unique_baselines: np.ndarray, baseline_set: np.ndarray
 ) -> np.ndarray:
-    """Finds the baseline indices of a set of baselines using the unique baselines.
+    """
+    Finds the baseline indices of a set of baselines using the unique baselines.
 
     Uses a pairing function to reduce the number of values so it's more
     efficient to find the indices.
 
-    Args:
-        unique_baselines (np.ndarray): a 2D array of unique antenna pairs
-        (baselines).
-        baseline_set (np.ndarray): a 2D array of antenna pairs (baselines). This
-        array may contain duplicates.
+    Parameters
+    ----------
+    unique_baselines : np.ndarray
+        a 2D array of unique antenna pairs (baselines).
+    baseline_set : np.ndarray
+        a 2D array of antenna pairs (baselines). This array may contain duplicates.
 
-    Returns:
-        baseline_indices (np.ndarray): the indices of the baseline set that
+    Returns
+    -------
+    baseline_indices : np.ndarray
+        the indices of the baseline set that
         correspond to the unique baselines.
     """
     unique_baselines_paired = pairing_function(unique_baselines)
@@ -345,12 +413,31 @@ def read_all_cols_bvars(
     tb_tool: tables.table,
     chunks: Tuple[int, ...],
     chan_cnt: int,
-    ignore_msv2_cols,
+    ignore_msv2_cols: bool,
     delayed_params: Tuple,
     bvars: Dict[str, xr.DataArray],
 ) -> None:
     """
     Loops over each column and create delayed dask arrays
+
+    Parameters
+    ----------
+    tb_tool : tables.table
+
+    chunks : Tuple[int, ...]
+
+    chan_cnt : int
+
+    ignore_msv2_cols : bool
+
+    delayed_params : Tuple
+
+    bvars : Dict[str, xr.DataArray]
+
+
+    Returns
+    -------
+
     """
 
     col_names = tb_tool.colnames()
@@ -430,6 +517,17 @@ def concat_bvars_update_tvars(
     concats all the dask chunks from each baseline. This is intended to
     be called iteratively, for every time chunk iteration, once all the
     baseline chunks have been read.
+
+    Parameters
+    ----------
+    bvars: Dict[str, xr.DataArray]
+
+    tvars: Dict[str, xr.DataArray]
+
+
+    Returns
+    -------
+
     """
     for kk in bvars.keys():
         if len(bvars[kk]) == 0:
@@ -446,12 +544,21 @@ def concat_tvars_to_mvars(
     Concat into a single dask array all the dask arrays from each time
     chunk to make the final arrays of the xds.
 
-    :param dims: dimension names
-    :param tvars: variables as lists of dask arrays per time chunk
-    :param pol_cnt: len of pol axis/dim
-    :param chan_cnt: len of freq axis/dim (chan indices)
+    Parameters
+    ----------
+    dims : List[str]
+        dimension names
+    tvars : Dict[str, xr.DataArray]
+        variables as lists of dask arrays per time chunk
+    pol_cnt : int
+        len of pol axis/dim
+    chan_cnt : int
+        len of freq axis/dim (chan indices)
 
-    :return: variables as concated dask arrays
+    Returns
+    -------
+    Dict[str, xr.DataArray]
+        variables as concated dask arrays
     """
 
     mvars = {}
@@ -494,6 +601,24 @@ def read_flat_main_table(
     features may be missing and/or flaky.
 
     Chunk tuple: (row, freq, pol)
+
+    Parameters
+    ----------
+    infile : str
+
+    ddi : Union[int, None] (Default value = None)
+
+    scan_state : Union[Tuple[int, int], None] (Default value = None)
+
+    rowidxs : np.ndarray (Default value = None)
+
+    ignore_msv2_cols : Union[List, None] (Default value = None)
+
+    chunks : Tuple[int, ...] (Default value = (22000, 512, 2))
+
+    Returns
+    -------
+    Tuple[xr.Dataset, Dict[str, Any], Dict[str, Any]]
     """
     taql_where = f"where DATA_DESC_ID = {ddi}"
     if scan_state:

--- a/src/xradio/vis/_vis_utils/_ms/_tables/read_subtables.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read_subtables.py
@@ -28,8 +28,15 @@ def read_ephemerides(
     """
     Read ephemerides info from MSv2 FIELD/EPHEMi_....tab subtables
 
-    :param infile: path to MS
-    :return: ephemerides xds with metainfo as in the MSv3/EPHEMERIDES subtable
+    Parameters
+    ----------
+    infile : str
+        path to MS
+
+    Returns
+    -------
+    Union[xr.Dataset, None]
+        ephemerides xds with metainfo as in the MSv3/EPHEMERIDES subtable
     """
     field_subt = Path(infile, "FIELD")
     subdirs = [
@@ -62,9 +69,21 @@ def read_delayed_pointing_table(
     """
     Read MS pointing subtable in delayed arrays into an xr.Dataset
 
-    :param infile: path to pointing table
-    :rename_ids: dict with dimension renaming mapping
-    :param chunks: chunks for the arrays. Chunks tuple: time, antenna, data_vars_dim_1, data_vars_dim_2
+    Parameters
+    ----------
+    infile : str
+        path to pointing table
+    rename_ids : Dict[str, str] (Default value = None)
+        dict with dimension renaming mapping
+    chunks : Tuple (Default value = (10000, 100, 2, 20))
+        chunks for the arrays. Chunks tuple: time, antenna, data_vars_dim_1, data_vars_dim_2
+    time_slice: slice
+        time bounds
+
+    Returns
+    -------
+    xr.Dataset
+        pointing dataset
     """
 
     with open_table_ro(infile) as mtable:
@@ -124,18 +143,25 @@ def read_delayed_pointing_table(
     return xds
 
 
-def normalize_time_slice(mtable: tables.table, time_slice: slice):
+def normalize_time_slice(mtable: tables.table, time_slice: slice) -> slice:
     """
     If we get indices, produce the TIME column time value for the
     start/top indices. If we get timestamps, convert them to casacore
     refeference.
 
-    :param mtable: a casacore table from which we are reading a TIME
-    column
-    :param time_slice: slice giving start/stop time. Can be given as
-    integer indices or as timestamps (Xarray / pandas reference)
+    Parameters
+    ----------
+    mtable : tables.table
+        a casacore table from which we are reading a TIME
+        column
+    time_slice : slice
+        slice giving start/stop time. Can be given as
+        integer indices or as timestamps (Xarray / pandas reference)
 
-    :return: a (start, stop) slice with times in casacore ref frame
+    Returns
+    -------
+    slice
+        a (start, stop) slice with times in casacore ref frame
     """
     if type(time_slice.start) == pd.Timestamp and type(time_slice.stop) == pd.Timestamp:
         # Add tol?
@@ -189,12 +215,25 @@ def read_delayed_pointing_times(
     Read pointing table in delayed time / antenna chunks. Loops over
     time chunks
 
-    :param infile: path to pointing table
-    :param antennas: antenna ids
-    :param utimes: unique times from table
-    :param chunks: chunks for the arrays
-    :param query_all: table to read columns
-    :return: dictionary of columns=>variables (read as dask.delayed)
+    Parameters
+    ----------
+    infile : str
+        path to pointing table
+    antennas : np.ndarray
+        antenna ids
+    utimes : np.ndarray
+        unique times from table
+    chunks : tuple
+        chunks for the arrays
+    query_all : tables.table
+        table to read columns
+    time_slice: slice :
+        time bounds
+
+    Returns
+    -------
+    Dict[str, xr.DataArray]
+        dictionary of columns=>variables (read as dask.delayed)
     """
 
     antenna_chunks = range(0, len(antennas), chunks[1])
@@ -232,7 +271,7 @@ def read_delayed_pointing_chunks(
     infile: str,
     antennas: np.ndarray,
     chunks: tuple,
-    utimes: np.array,
+    utimes: np.ndarray,
     tc: int,
     tb_tool: tables.table,
 ) -> Dict[str, xr.DataArray]:
@@ -240,13 +279,25 @@ def read_delayed_pointing_chunks(
     For one time chunk, read the baseline/antenna chunks. Loops over
     antenna_id chunks and reads all columns as dask.delayed calls.
 
-    :param infile: path to pointing table
-    :param antennas: antenna ids
-    :param chunks: chunks for the arrays
-    :param utimes: unique times from table
-    :param tc: time index
-    :param tb_tool: table to read columns
-    :return: dictionary of columns=>variables (read as dask.delayed)
+    Parameters
+    ----------
+    infile : str
+        path to pointing table
+    antennas : np.ndarray
+        antenna ids
+    chunks : tuple
+        chunks for the arrays
+    utimes : np.ndarray
+        unique times from table
+    tc : int
+        time index
+    tb_tool : tables.table
+        table to read columns
+
+    Returns
+    -------
+    Dict[str, xr.DataArray]
+        dictionary of columns=>variables (read as dask.delayed)
     """
 
     # add a tol around the time ranges returned by taql, for the next taql queries

--- a/src/xradio/vis/_vis_utils/_ms/_tables/write.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/write.py
@@ -8,11 +8,19 @@ from casacore import tables
 
 
 def revert_time(datetimes: np.ndarray) -> np.ndarray:
-    """Convert time back from pandas datetime ref to casacore ref
+    """
+    Convert time back from pandas datetime ref to casacore ref
     (reverse of read.convert_casacore_time).
 
-    :param rawtimes: times in pandas reference
-    :return: times converted to casacore reference
+    Parameters
+    ----------
+    datetimes : np.ndarray
+        times in pandas reference
+
+    Returns
+    -------
+    np.ndarray
+        times converted to casacore reference
 
     """
     return (datetimes.astype(float) / 10**9) + 3506716800.0
@@ -151,14 +159,16 @@ def write_generic_table(xds: xr.Dataset, outfile: str, subtable="", cols=None):
     Parameters
     ----------
     xds : xr.Dataset
-        Source xarray dataset data
+
     outfile : str
-        Destination filename (or parent main table if writing subtable)
-    subtable : str
-        Name of the subtable being written, triggers special logic to add subtable to
-        parent table.  Default '' for normal generic writes
-    cols : str or list
-        List of cols to write. Default None writes all columns
+
+    subtable : str (Default value = "")
+
+    cols : List[str] (Default value = None)
+
+    Returns
+    -------
+
     """
     outfile = os.path.expanduser(outfile)
     logger.debug("writing {os.path.join(outfile, subtable)}")
@@ -232,6 +242,25 @@ def write_main_table_slice(
 ):
     """
     Write an xds row chunk to the corresponding main table slice
+
+    Parameters
+    ----------
+    xda : xr.DataArray
+
+    outfile : str
+
+    ddi : int
+
+    col : str
+
+    full_shape : Tuple
+
+    starts : Tuple
+
+
+    Returns
+    -------
+
     """
     # trigger the DAG for this chunk and return values while the table is unlocked
     values = xda.compute().values

--- a/src/xradio/vis/_vis_utils/_ms/_tables/write_exp_api.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/write_exp_api.py
@@ -1,5 +1,5 @@
 import os, time
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import dask
 import numpy as np

--- a/src/xradio/vis/_vis_utils/_ms/_tables/write_exp_api.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/write_exp_api.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import dask
 import numpy as np
+import xarray as xr
 
 
 from ..._utils.xds_helper import flatten_xds, calc_optimal_ms_chunk_shape
@@ -13,38 +14,43 @@ from casacore import tables
 
 
 def write_ms(
-    mxds,
-    outfile,
-    infile=None,
-    subtables=False,
-    modcols=None,
-    verbose=False,
-    execute=True,
+    mxds: xr.Dataset,
+    outfile: str,
+    infile: str =None,
+    subtables: bool = False,
+    modcols: Union[List[str], None] = None,
+    verbose: bool = False,
+    execute: bool = True,
 ) -> Optional[list]:
     """
     Write ms format xds contents back to casacore MS (CTDS - casacore Table Data System) format on disk
 
     Parameters
     ----------
-    mxds : xarray.Dataset
+    mxds : xr.Dataset,
         Source multi-xarray dataset (originally created by read_ms)
     outfile : str
         Destination filename
-    infile : str
+    infile : Union[str, None] (Default value = None)
         Source filename to copy subtables from. Generally faster than reading/writing through mxds via the subtables parameter. Default None
         does not copy subtables to output.
-    subtables : bool
+    subtables : bool (Default value = False)
         Also write subtables from mxds. Default of False only writes mxds attributes that begin with xdsN to the MS main table.
         Setting to True will write all other mxds attributes to subtables of the main table.  This is probably going to be SLOW!
         Use infile instead whenever possible.
-    modcols : list
+    modcols : Union[List[str], None] (Default value = None)
         List of strings indicating what column(s) were modified (aka xds data_vars). Different logic can be applied to speed up processing when
         a data_var has not been modified from the input. Default None assumes everything has been modified (SLOW)
-    verbose : bool
+    verbose : bool (Default value = False)
         Whether or not to print output progress. Since writes will typically execute the DAG, if something is
         going to go wrong, it will be here.  Default False
-    execute : bool
+    execute : bool (Default value = True)
         Whether or not to actually execute the DAG, or just return it with write steps appended. Default True will execute it
+
+    Returns
+    -------
+    Optional[list]
+        delayed write functions
     """
     outfile = os.path.expanduser(outfile)
     if verbose:
@@ -199,38 +205,41 @@ def write_ms(
 
 
 def write_ms_serial(
-    mxds,
-    outfile,
-    infile=None,
-    subtables=False,
-    verbose=False,
-    execute=True,
-    memory_available_in_bytes=500000000000,
+    mxds: xr.Dataset,
+    outfile: str,
+    infile: str = None,
+    subtables: bool = False,
+    verbose: bool = False,
+    execute: bool = True,
+    memory_available_in_bytes: int = 500000000000,
 ):
     """
     Write ms format xds contents back to casacore table format on disk
 
     Parameters
     ----------
-    mxds : xarray.Dataset
+    mxds : xr.Dataset
         Source multi-xarray dataset (originally created by read_ms)
     outfile : str
         Destination filename
-    infile : str
+    infile : str (Default value = None)
         Source filename to copy subtables from. Generally faster than reading/writing through mxds via the subtables parameter. Default None
         does not copy subtables to output.
-    subtables : bool
+    subtables : bool (Default value = False)
         Also write subtables from mxds. Default of False only writes mxds attributes that begin with xdsN to the MS main table.
         Setting to True will write all other mxds attributes to subtables of the main table.  This is probably going to be SLOW!
         Use infile instead whenever possible.
-    modcols : list
-        List of strings indicating what column(s) were modified (aka xds data_vars). Different logic can be applied to speed up processing when
-        a data_var has not been modified from the input. Default None assumes everything has been modified (SLOW)
-    verbose : bool
+    verbose : bool (Default value = False)
         Whether or not to print output progress. Since writes will typically execute the DAG, if something is
         going to go wrong, it will be here.  Default False
-    execute : bool
+
+    execute : bool (Default value = True)
         Whether or not to actually execute the DAG, or just return it with write steps appended. Default True will execute it
+    memory_available_in_bytes : (Default value = 500000000000)
+
+    Returns
+    -------
+
     """
 
     print("*********************")

--- a/src/xradio/vis/_vis_utils/_ms/_tables/write_exp_api.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/write_exp_api.py
@@ -16,7 +16,7 @@ from casacore import tables
 def write_ms(
     mxds: xr.Dataset,
     outfile: str,
-    infile: str =None,
+    infile: str = None,
     subtables: bool = False,
     modcols: Union[List[str], None] = None,
     verbose: bool = False,

--- a/src/xradio/vis/_vis_utils/_ms/chunks.py
+++ b/src/xradio/vis/_vis_utils/_ms/chunks.py
@@ -20,8 +20,15 @@ def read_spw_ddi_ant_pol(inpath: str) -> Tuple[xr.Dataset]:
     """
     Reads the four metainfo subtables needed to load data chunks into xdss.
 
-    :param inpath: MS path (main table)
-    :return: tuple with antenna, ddi, spw, and polarization setup subtables info
+    Parameters
+    ----------
+    inpath : str
+        MS path (main table)
+
+    Returns
+    -------
+    Tuple[xr.Dataset]
+        tuple with antenna, ddi, spw, and polarization setup subtables info
     """
     spw_xds = read_generic_table(
         inpath,
@@ -41,7 +48,8 @@ def read_spw_ddi_ant_pol(inpath: str) -> Tuple[xr.Dataset]:
 def load_main_chunk(
     infile: str, chunk: Dict[str, slice]
 ) -> Dict[Tuple[int, int], xr.Dataset]:
-    """Loads a chunk of visibility data. For every DDI, a separate
+    """
+    Loads a chunk of visibility data. For every DDI, a separate
     dataset is produced.
     This is very loosely equivalent to the
     partitions.read_*_partitions functions, but in a load (not lazy)
@@ -51,10 +59,17 @@ def load_main_chunk(
     Xarray datasets. It produces one dataset per DDI found within the
     chunk slice of time/baseline.
 
-    :param infile: MS path (main table)
-    :param chunk: specification of chunk to load
+    Parameters
+    ----------
+    infile : str
+        MS path (main table)
+    chunk : Dict[str, slice]
+        specification of chunk to load
 
-    :return: dictionary of chunk datasets (keys are spw and pol_setup IDs)
+    Returns
+    -------
+    Dict[Tuple[int, int], xr.Dataset]
+        dictionary of chunk datasets (keys are spw and pol_setup IDs)
     """
 
     chunk_dims = ["time", "baseline", "freq", "pol"]
@@ -97,12 +112,20 @@ def finalize_chunks(
     Adds pointing variables to a dictionary of chunk xdss. This is
     intended to be added after reading chunks from an MS main table.
 
-    :param infile: MS path (main table)
-    :param chunks: chunk xdss
-    :param chunk_spec: specification of chunk to load
+    Parameters
+    ----------
+    infile : str
+        MS path (main table)
+    chunks : Dict[str, xr.Dataset]
+        chunk xdss
+    chunk_spec : Dict[str, slice]
+        specification of chunk to load
 
-    :return: dictionary of chunk xdss where every xds now has pointing
-    data variables
+    Returns
+    -------
+    Dict[Tuple[int, int], xr.Dataset]
+        dictionary of chunk xdss where every xds now has pointing
+        data variables
     """
     pnt_name = "POINTING"
     pnt_path = Path(infile, pnt_name)
@@ -125,16 +148,24 @@ def finalize_chunks(
     return pnt_chunks
 
 
-def finalize_chunk_xds(infile: str, chunk_xds: xr.Dataset, pointing_xds) -> xr.Dataset:
+def finalize_chunk_xds(infile: str, chunk_xds: xr.Dataset, pointing_xds: xr.Dataset) -> xr.Dataset:
     """
     Adds pointing variables to one chunk xds.
 
-    :param infile: MS path (main table)
-    :param xds_chunk: chunks xds
-    :param pointing_xds: pointing (sub)table xds
+    Parameters
+    ----------
+    infile : str
+        MS path (main table)
+    xds_chunk : xr.Dataset
+        chunks xds
+    pointing_xds : xr.Dataset
+        pointing (sub)table xds
 
-    :return: chunk xds with pointing data variables interpolated form
-    the pointing (sub)table
+    Returns
+    -------
+    xr.Dataset
+        chunk xds with pointing data variables interpolated form
+        the pointing (sub)table
     """
 
     interp_pnt = pointing_xds.interp(time=chunk_xds.time, method="nearest")

--- a/src/xradio/vis/_vis_utils/_ms/chunks.py
+++ b/src/xradio/vis/_vis_utils/_ms/chunks.py
@@ -148,7 +148,9 @@ def finalize_chunks(
     return pnt_chunks
 
 
-def finalize_chunk_xds(infile: str, chunk_xds: xr.Dataset, pointing_xds: xr.Dataset) -> xr.Dataset:
+def finalize_chunk_xds(
+    infile: str, chunk_xds: xr.Dataset, pointing_xds: xr.Dataset
+) -> xr.Dataset:
     """
     Adds pointing variables to one chunk xds.
 

--- a/src/xradio/vis/_vis_utils/_ms/conversion.py
+++ b/src/xradio/vis/_vis_utils/_ms/conversion.py
@@ -8,6 +8,8 @@ import graphviper.utils.logger as logger
 import numpy as np
 import xarray as xr
 
+from casacore import tables
+
 from .msv4_infos import create_field_info
 from .msv4_sub_xdss import create_ant_xds, create_pointing_xds, create_weather_xds
 from .msv2_to_msv4_meta import (
@@ -46,7 +48,7 @@ def parse_chunksize(
 
     Returns
     -------
-    _dict_
+    Dict[str, int]
         dictionary of chunk sizes (as dim->size)
     """
     if isinstance(chunksize, dict):
@@ -103,7 +105,7 @@ def mem_chunksize_to_dict(
 
     Returns
     -------
-    _dict_
+    Dict[str, int]
         dictionary of chunk sizes (as dim->size)
     """
 
@@ -184,7 +186,7 @@ def mem_chunksize_to_dict_main_balanced(
 
     Returns
     -------
-    _dict_
+    Dict[str, int]
         dictionary of chunk sizes (as dim->size)
     """
 
@@ -341,7 +343,7 @@ def itemsize_pointing_spec(xds: xr.Dataset) -> int:
     return itemsize
 
 
-def calc_used_gb(chunksizes: dict, baseline_or_antenna_id: str, sizeof_vis: int):
+def calc_used_gb(chunksizes: dict, baseline_or_antenna_id: str, sizeof_vis: int) -> float:
     return (
         chunksizes["time"]
         * chunksizes[baseline_or_antenna_id]
@@ -517,7 +519,7 @@ def create_coordinates(
     return xds
 
 
-def find_min_max_times_taql(tb_tool, taql_where: str):
+def find_min_max_times_taql(tb_tool: tables.table, taql_where: str) -> str:
     """
     Find the min/max times in an MSv4, for constraining pointing.
 

--- a/src/xradio/vis/_vis_utils/_ms/conversion.py
+++ b/src/xradio/vis/_vis_utils/_ms/conversion.py
@@ -56,8 +56,10 @@ def parse_chunksize(
     elif isinstance(chunksize, float):
         chunksize = mem_chunksize_to_dict(chunksize, xds_type, xds)
     elif chunksize is not None:
-        raise ValueError(f"Chunk size expected as a dict or a float, got: "
-                         f" {chunksize} (of type {type(chunksize)}")
+        raise ValueError(
+            f"Chunk size expected as a dict or a float, got: "
+            f" {chunksize} (of type {type(chunksize)}"
+        )
 
     return chunksize
 
@@ -343,7 +345,9 @@ def itemsize_pointing_spec(xds: xr.Dataset) -> int:
     return itemsize
 
 
-def calc_used_gb(chunksizes: dict, baseline_or_antenna_id: str, sizeof_vis: int) -> float:
+def calc_used_gb(
+    chunksizes: dict, baseline_or_antenna_id: str, sizeof_vis: int
+) -> float:
     return (
         chunksizes["time"]
         * chunksizes[baseline_or_antenna_id]

--- a/src/xradio/vis/_vis_utils/_ms/descr.py
+++ b/src/xradio/vis/_vis_utils/_ms/descr.py
@@ -3,6 +3,7 @@ from typing import Dict, Union
 
 import numpy as np
 import pandas as pd
+import xarray as xr
 
 from ._tables.read import read_generic_table, read_flat_col_chunk
 from ._tables.table_query import open_query, open_table_ro
@@ -10,21 +11,29 @@ from xradio.vis._vis_utils._ms.optimised_functions import unique_1d
 
 
 def describe_ms(
-    infile: str, mode="summary", rowmap: Union[dict, None] = None
+    infile: str, mode: str = "summary", rowmap: Union[dict, None] = None
 ) -> Union[pd.DataFrame, Dict]:
     """
     Summarize the contents of an MS directory in casacore table format
 
-    :param infile: input MS filename
-    :param mode: type of information returned ('summary', 'flat', 'expanded').
-    'summary' returns a pandas dataframe that is nice for displaying in notebooks
-    etc. 'flat' returns a list of tuples of (ddi, row, chan, pol). 'expanded'
-    returns a list of tuples of (ddi, time, baseline, chan, pol). These latter two
-    are good for trying to determine chunk size for read_ms(expand=True/False).
-    :param rowmap: dict of DDI to tuple of (row indices, channel indices). Returned
-    by ms_selection function. Default None ignores selections
+    Parameters
+    ----------
+    infile : str
+        input MS filename
+    mode : str (Default value = "summary")
+        type of information returned ('summary', 'flat', 'expanded').
+        'summary' returns a pandas dataframe that is nice for displaying in notebooks
+        etc. 'flat' returns a list of tuples of (ddi, row, chan, pol). 'expanded'
+        returns a list of tuples of (ddi, time, baseline, chan, pol). These latter two
+        are good for trying to determine chunk size for read_ms(expand=True/False). (Default value = "summary")
+    rowmap : Union[dict, None] (Default value = None)
+        dict of DDI to tuple of (row indices, channel indices). Returned
+        by ms_selection function. Default None ignores selections
 
-    :return: summary as a pd dataframe
+    Returns
+    -------
+    Union[pd.DataFrame, Dict]
+        summary as a pd dataframe
     """
     infile = os.path.expanduser(infile)  # does nothing if $HOME is unknown
     if not os.path.isdir(infile):
@@ -57,16 +66,29 @@ def describe_ms(
 
 
 def populate_ms_descr(
-    infile, mode, query_per_ddi, summary, ddi, ddi_xds, rowmap=None
+    infile: str, mode: str, query_per_ddi, summary: dict, ddi: int, ddi_xds: xr.Dataset, rowmap: Union[Dict, None] = None
 ) -> pd.DataFrame:
-    """Adds information from the time and baseline (antenna1+antenna2)
+    """
+    Adds information from the time and baseline (antenna1+antenna2)
     columns as well as channel and polarizations, based on a taql
     query.
 
-    :param mode: mode (as in describe_ms())
-    :param query_per_ddi: a TaQL query with data per individual DDI
-    :param sdf: summary dict being populated
-    :param summary: final summary object being populated from the invividual sdf's
+    Parameters
+    ----------
+    infile : str
+        input table/MS path
+    mode : str
+        mode (as in describe_ms())
+    query_per_ddi :
+        a TaQL query with data per individual DDI
+    summary : Dict
+        summary dict being populated
+    ddi_xds : xr.Dataset
+        final summary object being populated from the invividual sdf's
+
+    Returns
+    -------
+    pd.DataFrame
     """
     spw_ids = ddi_xds.spectral_window_id.values
     pol_ids = ddi_xds.polarization_id.values

--- a/src/xradio/vis/_vis_utils/_ms/descr.py
+++ b/src/xradio/vis/_vis_utils/_ms/descr.py
@@ -66,7 +66,13 @@ def describe_ms(
 
 
 def populate_ms_descr(
-    infile: str, mode: str, query_per_ddi, summary: dict, ddi: int, ddi_xds: xr.Dataset, rowmap: Union[Dict, None] = None
+    infile: str,
+    mode: str,
+    query_per_ddi,
+    summary: dict,
+    ddi: int,
+    ddi_xds: xr.Dataset,
+    rowmap: Union[Dict, None] = None,
 ) -> pd.DataFrame:
     """
     Adds information from the time and baseline (antenna1+antenna2)

--- a/src/xradio/vis/_vis_utils/_ms/msv4_sub_xdss.py
+++ b/src/xradio/vis/_vis_utils/_ms/msv4_sub_xdss.py
@@ -11,7 +11,8 @@ from ._tables.read import read_generic_table
 
 
 def create_ant_xds(in_file: str):
-    """Creates an Antenna Xarray Dataset from a MS v2 ANTENNA table.
+    """
+    Creates an Antenna Xarray Dataset from a MS v2 ANTENNA table.
 
     Parameters
     ----------
@@ -20,7 +21,7 @@ def create_ant_xds(in_file: str):
 
     Returns
     -------
-    ant_xds : xarray.Dataset
+    xr.Dataset
         Antenna Xarray Dataset.
     """
     # Dictionaries that define the conversion from MSv2 to MSv4:
@@ -94,7 +95,8 @@ def create_ant_xds(in_file: str):
 
 
 def create_weather_xds(in_file: str):
-    """Creates a Weather Xarray Dataset from a MS v2 WEATHER table.
+    """
+    Creates a Weather Xarray Dataset from a MS v2 WEATHER table.
 
     Parameters
     ----------
@@ -103,7 +105,7 @@ def create_weather_xds(in_file: str):
 
     Returns
     -------
-    weather_xds : xarray.Dataset
+    xr.Dataset
         Weather Xarray Dataset.
     """
     # Dictionaries that define the conversion from MSv2 to MSv4:
@@ -213,8 +215,9 @@ def create_weather_xds(in_file: str):
     return weather_xds
 
 
-def create_pointing_xds(in_file: str, taql_where: str, interp_time: Union[float, None] = None) -> xr.Dataset:
-    """Creates a Pointing Xarray Dataset from an MS v2 POINTING (sub)table.
+def create_pointing_xds(in_file: str, taql_where: str, interp_time: Union[xr.DataArray, None] = None) -> xr.Dataset:
+    """
+    Creates a Pointing Xarray Dataset from an MS v2 POINTING (sub)table.
 
     WIP: details of a few direction variables (and possibly moving some to attributes) to be
     settled (see MSv4 spreadsheet).
@@ -223,17 +226,15 @@ def create_pointing_xds(in_file: str, taql_where: str, interp_time: Union[float,
     ----------
     in_file : str
         Input MS name.
-
     taql_where : str
         TaQL where string to constrain TIME, etc.
-
-    interp_time : xr.DataArray
+    interp_time : Union[xr.DataArray, None] (Default value = None)
         interpolate time to this (presumably main dataset time)
 
     Returns
     -------
-    pointing_xds : xarray.Dataset
-        Pointing Xarray Dataset.
+    xr.Dataset
+         Pointing Xarray dataset
     """
     start = time.time()
 

--- a/src/xradio/vis/_vis_utils/_ms/msv4_sub_xdss.py
+++ b/src/xradio/vis/_vis_utils/_ms/msv4_sub_xdss.py
@@ -215,7 +215,9 @@ def create_weather_xds(in_file: str):
     return weather_xds
 
 
-def create_pointing_xds(in_file: str, taql_where: str, interp_time: Union[xr.DataArray, None] = None) -> xr.Dataset:
+def create_pointing_xds(
+    in_file: str, taql_where: str, interp_time: Union[xr.DataArray, None] = None
+) -> xr.Dataset:
     """
     Creates a Pointing Xarray Dataset from an MS v2 POINTING (sub)table.
 

--- a/src/xradio/vis/_vis_utils/_ms/optimised_functions.py
+++ b/src/xradio/vis/_vis_utils/_ms/optimised_functions.py
@@ -5,42 +5,60 @@ import pandas as pd
 
 
 def unique_1d(array: np.ndarray) -> np.ndarray:
-    """Optimised version of np.unique for 1D arrays.
+    """
+    Optimised version of np.unique for 1D arrays.
 
-    Args:
-        array (np.ndarray): a 1D array of values.
+    Parameters
+    ----------
+    array : np.ndarray
+        a 1D array of values.
 
-    Returns:
-        np.ndarray: a sorted array of unique values.
+    Returns
+    -------
+    np.ndarray
+        a sorted array of unique values.
+
     """
     return np.sort(pd.unique(array))
 
 
 def pairing_function(antenna_pairs: np.ndarray) -> np.ndarray:
-    """Pairing function to convert each array pair to a single value.
+    """
+    Pairing function to convert each array pair to a single value.
 
     This custom pairing function will only work if the maximum value is less
     than 2**20 and less than 2,048 if using signed 32-bit integers.
 
-    Args:
-        antenna_pairs (np.ndarray): a 2D array containing antenna 1 and antenna
+    Parameters
+    ----------
+    antenna_pairs : np.ndarray
+        a 2D array containing antenna 1 and antenna
         2 ids, which forms a baseline.
 
-    Returns:
-        np.ndarray: a 1D array of the paired values.
+    Returns
+    -------
+    np.ndarray
+        a 1D array of the paired values.
+
     """
     return antenna_pairs[:, 0] * 2**20 + antenna_pairs[:, 1]
 
 
 def inverse_pairing_function(paired_array: np.ndarray) -> np.ndarray:
-    """Inverse pairing function to convert each paired value to an antenna pair.
+    """
+    Inverse pairing function to convert each paired value to an antenna pair.
 
     This inverse pairing function is the inverse of the custom pairing function.
 
-    Args:
-        paired_array (np.ndarray): a 1D array of the paired values.
+    Parameters
+    ----------
+    paired_array : np.ndarray
+        a 1D array of the paired values.
 
-    Returns:
-        np.ndarray: a 2D array containing antenna 1 and antenna 2 ids.
+    Returns
+    -------
+    np.ndarray
+        a 2D array containing antenna 1 and antenna 2 ids.
+
     """
     return np.column_stack(np.divmod(paired_array, 2**20))

--- a/src/xradio/vis/_vis_utils/_ms/partition_queries.py
+++ b/src/xradio/vis/_vis_utils/_ms/partition_queries.py
@@ -17,13 +17,22 @@ from .subtables import subt_rename_ids
 def make_partition_ids_by_ddi_scan(
     infile: str, do_subscans: bool
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Produces arrays of per-partition ddi, scan, state_id, for when
+    """
+    Produces arrays of per-partition ddi, scan, state_id, for when
     using partiion schemes 'scan' or 'scan/subscan', that is
     partitioning by some variant of (ddi, scan, subscan(state_id))
 
-    :param infile: Path to MS
-    :param do_subscans: also partitioning by subscan, not only scan
-    :return: arrays with indices that define every partition
+    Parameters
+    ----------
+    infile : str
+        Path to MS
+    do_subscans : bool
+        also partitioning by subscan, not only scan
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray, np.ndarray]
+        arrays with indices that define every partition
     """
     try:
         cctable = None
@@ -69,16 +78,24 @@ def make_partition_ids_by_ddi_scan(
 def partition_when_empty_state(
     infile: str,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    """Generate fallback partition ids when trying to partition by
+    """
+    Generate fallback partition ids when trying to partition by
     'intent' but the STATE table is empty.
 
     Some MSs have no STATE rows and in the main table STATE_ID==-1
     (that is not a valid MSv2 but it happens).
 
-    :param infile: Path to the MS
-    :return: same as make_partition_ids_by_ddi_intent but with
-    effectively only ddi indices and other indices set to None ("any
-    IDs found")
+    Parameters
+    ----------
+    infile : str
+        Path to the MS
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+        same as make_partition_ids_by_ddi_intent but with
+        effectively only ddi indices and other indices set to None ("any
+        IDs found")
     """
     try:
         main_table = None
@@ -107,14 +124,22 @@ def partition_when_empty_state(
 def find_distinct_obs_mode(
     infile: str, state_table: tables.table
 ) -> Union[List[str], None]:
-    """Produce a list of unique "scan/subscan" intents.
+    """
+    Produce a list of unique "scan/subscan" intents.
 
-    :param infile: Path to the MS
-    :param state_table: casacore table object to read from
-    :return: List of unique "scan/subscan" intents as given in the
-    OBS_MODE column of the STATE subtable. None if the STATE subtable
-    is empty or there is a problem reading it
+    Parameters
+    ----------
+    infile : str
+        Path to the MS
+    state_table : tables.table
+        casacore table object to read from
 
+    Returns
+    -------
+    Union[List[str], None]
+        List of unique "scan/subscan" intents as given in the
+        OBS_MODE column of the STATE subtable. None if the STATE subtable
+        is empty or there is a problem reading it
     """
     taql_distinct_intents = "select DISTINCT OBS_MODE from $state_table"
     with open_query(state_table, taql_distinct_intents) as query_intents:
@@ -134,7 +159,8 @@ def find_distinct_obs_mode(
 def filter_intents_per_ddi(
     ddis: List[int], substr: str, intents: str, spw_name_by_ddi: Dict[int, str]
 ) -> List[str]:
-    """For a given pair of:
+    """
+    For a given pair of:
     - substring (say 'WVR') associated with a type of intent we want to differentiate
     - intents string (multiple comma-separated scan/subscan intents)
     => do: for every DDI passed in the list of ddis, either keep only the
@@ -142,14 +168,23 @@ def filter_intents_per_ddi(
     whether that substring is present in the SPW name. This is to filter in only
     the intents that really apply to every DDI/SPW.
 
-    :param ddis: list of ddis for which the intents have to be filtered
-    :param substr: substring to filter by
-    :param intents: string with a comma-separated list of individual
-    scan/subscan intent strings (like scan/subscan intents as stored
-    in the MS STATE/OBS_MODE
-    :param spw_name_by_ddi: SPW names by DDI ID (row index) key
-    :return: list where the intents related to 'substr' have been filtered in our out
+    Parameters
+    ----------
+    ddis : List[int]
+        list of ddis for which the intents have to be filtered
+    substr : str
+        substring to filter by
+    intents : str
+        string with a comma-separated list of individual
+        scan/subscan intent strings (like scan/subscan intents as stored
+        in the MS STATE/OBS_MODE
+    spw_name_by_ddi : Dict[int, str]
+        SPW names by DDI ID (row index) key
 
+    Returns
+    -------
+    List[str]
+        list where the intents related to 'substr' have been filtered in our out
     """
     present = substr in intents
     # Nothing to effectively filter, full cs-list of intents apply to all DDIs
@@ -182,7 +217,8 @@ def make_ddi_state_intent_lists(
     distinct_obs_mode: np.ndarray,
     spw_name_by_ddi: Dict[int, str],
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Produce arrays of (ddi indices, state indices, intent string)
+    """
+    Produce arrays of (ddi indices, state indices, intent string)
     for every distinct intent string, where every item represents one
     partition of the main table
 
@@ -193,11 +229,21 @@ def make_ddi_state_intent_lists(
     intent is the only kept when the DDI/SPW has WVR in its name). See
     call to filter_intents_per_ddi()
 
-    :param main_tbl: main MS table openend as a casacore.tables.table
-    :state_tbl: STATE subtable openend as a casacore.tables.table
-    :param distinct_obs_mode: list of unique/distinct OBS_MODE strings from the STATE table
-    :return: arrays of (ddi indices, state indices, intent string)
+    Parameters
+    ----------
+    main_tbl : tables.table
+        main MS table openend as a casacore.tables.table
+    state_tbl : tables.table
+        STATE subtable openend as a casacore.tables.table
+    distinct_obs_mode : np.ndarray
+        list of unique/distinct OBS_MODE strings from the STATE table
+    spw_name_by_ddi: Dict[int, str]
 
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray, np.ndarray]
+        arrays of (ddi indices, state indices, intent string)
     """
     data_desc_id, state_id_partitions, intent_names = [], [], []
     for intent in distinct_obs_mode:
@@ -236,11 +282,21 @@ def make_ddi_state_intent_lists(
 def make_partition_ids_by_ddi_intent(
     infile: str, spw_names: xr.DataArray
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    """Produces arrays of per-partition ddi, scan, state_id, for when
+    """
+    Produces arrays of per-partition ddi, scan, state_id, for when
     using the partition scheme 'intents' (ddi, scan, subscans(state_ids))
 
-    :param infile:
-    :return: arrays with indices that define every partition
+    Parameters
+    ----------
+    infile : str
+        return: arrays with indices that define every partition
+    spw_names: xr.DataArray
+
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+        arrays with indices that define every partition
     """
     # TODO: could explore other TAQL alternatives, like
     # select ... from ::STATE where OBS_MODE = ...
@@ -297,7 +353,8 @@ def create_taql_query_and_file_name(out_file, intent, state_ids, field_id, ddi):
 
 
 def get_unqiue_intents(in_file):
-    """_summary_
+    """
+    _summary_
 
     Parameters
     ----------
@@ -334,7 +391,8 @@ def enumerated_product(*args):
 
 
 def create_partition_enumerated_product(in_file: str, partition_scheme: str):
-    """Creates an enumerated_product of the data_desc_ids, state_ids, field_ids in a MS v2 that define the partions in a processing set.
+    """
+    Creates an enumerated_product of the data_desc_ids, state_ids, field_ids in a MS v2 that define the partions in a processing set.
 
     Parameters
     ----------

--- a/src/xradio/vis/_vis_utils/_ms/partitions.py
+++ b/src/xradio/vis/_vis_utils/_ms/partitions.py
@@ -29,8 +29,19 @@ def make_spw_names_by_ddi(ddi_xds: xr.Dataset, spw_xds: xr.Dataset) -> Dict[int,
 
 
 def split_intents(intents: str):
-    """Make a dict with two scan / subscan levels of intents from an
+    """
+    Make a dict with two scan / subscan levels of intents from an
     intent string from the STATE/OBS_MODE of an MS.
+
+    Parameters
+    ----------
+    intents : str
+        intents "OBS_MODE" string from an MS/STATE row
+
+    Returns
+    -------
+    Dict[str, list]
+        per scan intent list of individual subscan intent strings
     """
     sub_sep = "#"
     if sub_sep not in intents:
@@ -60,13 +71,25 @@ def make_part_key(
     partition_scheme: str,
     intent: str = "",
     scan_state: Union[Tuple, None] = None,
-):
+) -> PartitionKey:
     """
     Makes the key that a partition (sub)xds will have in the partitions dictionary of a cds.
 
-    :param xds: partition xds with data and attrs
-    :param partition_scheme: one of the schemes supported in the read_ms_*_partitions() functions
-    :param scan_state: scan/state ids, required when partition_scheme != 'ddi'
+    Parameters
+    ----------
+    xds : xr.Dataset
+        partition xds with data and attrs
+    partition_scheme : str
+        one of the schemes supported in the read_ms_*_partitions() functions
+    intent : str (Default value = "")
+        partition intent
+    scan_state : Union[Tuple, None] (Default value = None)
+        scan/state ids, required when partition_scheme != 'ddi'
+
+    Returns
+    -------
+    PartitionKey
+        partition key
     """
     spw_id = xds.attrs["partition_ids"]["spw_id"]
     pol_setup_id = xds.attrs["partition_ids"]["pol_setup_id"]
@@ -91,17 +114,28 @@ def read_ms_scan_subscan_partitions(
     expand: bool = False,
     chunks: Union[Tuple[int], List[int], None] = None,
 ) -> Tuple[VisSetPartitions, Dict[str, xr.Dataset], List[str]]:
-    """partitions per scan_number/subscans
+    """
+    partitions per scan_number/subscans
     (main table column SCAN_NUMBER / STATE_ID)
 
-    :param infile: MS path (main table)
-    :param partition_scheme: this functions can do 'intent', 'scan', and 'scan/subscan'
-    :param expand: wether to use (time, baseline) dimensions rather than 1d (row)
-    (only relevant when using the read_flat variant of read functions)
-    :param chunk: Dask chunking as tuple (time, baseline, chan, pol)
-    :return: a dictionary of partitions, a dict of subtable
-    xr.Datasets to use later for metainformation, and a list of the
-    subtables already read
+    Parameters
+    ----------
+    infile : str
+        MS path (main table)
+    partition_scheme : str
+        this functions can do 'intent', 'scan', and 'scan/subscan'
+    expand : bool (Default value = False)
+        wether to use (time, baseline) dimensions rather than 1d (row)
+        (only relevant when using the read_flat variant of read functions)
+    chunk : Union[Tuple[int], List[int], None] (Default value = None)
+        Dask chunking as tuple (time, baseline, chan, pol)
+
+    Returns
+    -------
+    Tuple[VisSetPartitions, Dict[str, xr.Dataset], List[str]]
+        a dictionary of partitions, a dict of subtable
+        xr.Datasets to use later for metainformation, and a list of the
+        subtables already read
     """
 
     spw_xds = read_generic_table(
@@ -207,11 +241,23 @@ def read_ms_ddi_partitions(
     from the DDIs. First looks into the SPECTRAL_WINDOW, POLARIZATION,
     DATA_DESCRIPTION tables to define the partitions.
 
-    :param expand: redimension (row)->(time,baseline)
-    :param rowmap: to be removed
-    :param chunks: array data chunk sizes
-    :return: dictionary of partitions, dict of subtable xr.Datasets to use later
-    for metainformation, and a list of the subtables already read
+    Parameters
+    ----------
+    infile : str
+        input MS path
+    expand : bool (Default value = False)
+        redimension (row)->(time,baseline)
+    rowmap : Union[dict, None] (Default value = None)
+        to be removed
+    chunks : Union[Tuple[int], List[int], None] (Default value = None)
+        array data chunk sizes
+
+    Returns
+    -------
+    Tuple[VisSetPartitions, Dict[str, xr.Dataset], List[str]]
+        dictionary of partitions, dict of subtable xr.Datasets to use later
+        for metainformation, and a list of the subtables already read
+
     """
     # we need the antenna, spectral window, polarization, and data description tables
     # to define the (sub)datasets (their dims and coords) and to process the main table
@@ -319,13 +365,22 @@ def read_ms_ddi_partitions(
 def finalize_partitions(
     parts: Dict[str, xr.Dataset], subts: Dict[str, xr.Dataset]
 ) -> Dict[str, xr.Dataset]:
-    """Once the partition datasets and the metainfo/subtable datasets
+    """
+    Once the partition datasets and the metainfo/subtable datasets
     have been read, add to the partitions:
     - pointing variables from the pointing subtable
 
-    :param parts: partitions as xarray datasets, as read from an MS main table
-    :param subts: subtables of an MS read as xarray datasets
-    :return: partitions with additions taken from subtables
+    Parameters
+    ----------
+    parts : Dict[str, xr.Dataset]
+        partitions as xarray datasets, as read from an MS main table
+    subts : Dict[str, xr.Dataset]
+        subtables of an MS read as xarray datasets
+
+    Returns
+    -------
+    Dict[str, xr.Dataset]
+        partitions with additions taken from subtables
     """
     if "pointing" in subts:
         pointing = subts["pointing"]

--- a/src/xradio/vis/_vis_utils/_ms/subtables.py
+++ b/src/xradio/vis/_vis_utils/_ms/subtables.py
@@ -35,10 +35,20 @@ def read_ms_subtables(
     """
     Read MSv2 subtables (main table keywords) as xr.Dataset
 
-    :param infile: input MeasurementSet path
-    :param done_subt: Subtables that were already read, to skip them
-    :param asdm_subtables: Whether to also read ASDM_* subtables
-    :return: dict of xarray datasets read from subtables (metadata tables)
+    Parameters
+    ----------
+    infile : str
+        input MeasurementSet path
+    done_subt : List[str]
+        Subtables that were already read, to skip them
+    asdm_subtables : bool (Default value = False)
+        Whether to also read ASDM_* subtables
+
+    Returns
+    -------
+    Dict[str, xr.Dataset]
+        dict of xarray datasets read from subtables (metadata tables)
+
     """
     ignore_msv2_cols_subt = ["FLAG_CMD", "FLAG_ROW", "BEAM_ID"]
     skip_tables = ["SORTED_TABLE", "FLAG_CMD"] + done_subt
@@ -87,14 +97,23 @@ def read_ms_subtables(
 def add_pointing_to_partition(
     xds_part: xr.Dataset, xds_pointing: xr.Dataset
 ) -> xr.Dataset:
-    """Take pointing variables from a (delayed) pointing dataset and
+    """
+    Take pointing variables from a (delayed) pointing dataset and
     transfer them to a main table partition dataset (interpolating into
     the destination time axis)
 
-    :param xds_part: a partition/sub-xds of the main table
-    :param xds_pointing: the xds read from the pointing subtable
-    :return: partition xds with pointing variables added/interpolated from the
-    pointing_xds into its time axis
+    Parameters
+    ----------
+    xds_part : xr.Dataset
+        a partition/sub-xds of the main table
+    xds_pointing : xr.Dataset
+        the xds read from the pointing subtable
+
+    Returns
+    -------
+    xr.Dataset
+        partition xds with pointing variables added/interpolated from the
+        pointing_xds into its time axis
 
     """
     interp_xds = xds_pointing.interp(time=xds_part.time, method="nearest")

--- a/src/xradio/vis/_vis_utils/_utils/partition_attrs.py
+++ b/src/xradio/vis/_vis_utils/_utils/partition_attrs.py
@@ -29,11 +29,19 @@ VisGroup = TypedDict(
 
 
 def make_vis_group_attr(xds: xr.Dataset) -> Dict:
-    """Add an attribute with the initial data/vis groups that have been
+    """
+    Add an attribute with the initial data/vis groups that have been
     read from the MS (DATA / CORRECTED_DATA / MODEL_DATA)
 
-    :param xds: dataset to make the vis_group depending on its data_vars
-    :return: vis_group derived form this dataset
+    Parameters
+    ----------
+    xds : xr.Dataset
+        dataset to make the vis_group depending on its data_vars
+
+    Returns
+    -------
+    Dict
+        vis_group derived form this dataset
     """
     msv2_extended_vis_vars = ["vis", "vis_corrected", "vis_model"]
     msv2_col_names = ["DATA", "CORRECTED_DATA", "MODEL_DATA"]
@@ -87,7 +95,8 @@ def add_partition_attrs(
     part_ids: PartitionIds,
     other_attrs: Dict,
 ) -> xr.Dataset:
-    """add attributes to the xr.Dataset:
+    """
+    add attributes to the xr.Dataset:
     - sub-dict of partition-id related ones
     - sub-dict of data/vis groups
     - sub-dict of attributes coming from the lower level read
@@ -96,13 +105,23 @@ def add_partition_attrs(
     Produces the partition IDs that can be retrieved from the DD subtable and also
     adds the ones passed in part_ids
 
-    :param xds: dataset partition
-    :param ddi: DDI of this partition
-    :param ddi_xds: dataset for the DATA_DESCRIPTION subtable
-    :param part_ids: partition id attrs
-    :param other_attrs: additional attributes produced by the read functions
-    :return: dataset with attributes added
+    Parameters
+    ----------
+    xds : xr.Dataset
+        dataset partition
+    ddi : int
+        DDI of this partition
+    ddi_xds : xr.Dataset
+        dataset for the DATA_DESCRIPTION subtable
+    part_ids : PartitionIds
+        partition id attrs
+    other_attrs : Dict
+        additional attributes produced by the read functions
 
+    Returns
+    -------
+    xr.Dataset
+        dataset with attributes added
     """
 
     xds = xds.assign_attrs(

--- a/src/xradio/vis/_vis_utils/_utils/xds_helper.py
+++ b/src/xradio/vis/_vis_utils/_utils/xds_helper.py
@@ -12,7 +12,8 @@ from .stokes_types import stokes_types
 def make_coords(
     xds: xr.Dataset, ddi: int, subtables: Tuple[xr.Dataset, ...]
 ) -> Dict[str, np.ndarray]:
-    """Make the coords to be added to a partition or chunk (besides
+    """
+    Make the coords to be added to a partition or chunk (besides
     the time, baseline) basic structure
 
     Grabs:
@@ -20,7 +21,18 @@ def make_coords(
     - pol idxs from the pol+ddi subtables -> pol names via the stokes_types
     - antenna IDs from antenna subtable
 
-    :param: sub-xds as (ant_xds, ddi_xds, spw_xds, pol_xds)
+    Parameters
+    ----------
+    xds : xr.Dataset
+
+    ddi : int
+
+    subtables: Tuple[xr.Dataset, ...]
+
+
+    Returns
+    -------
+    Dict[str, np.ndarray]
     """
     ant_xds, ddi_xds, spw_xds, pol_xds = subtables
     freq = spw_xds.chan_freq.values[
@@ -46,15 +58,25 @@ def vis_xds_packager_cds(
     subtables: List[Tuple[str, xr.Dataset]],
     partitions: Dict[Any, xr.Dataset],
     descr_add: str = "",
-):
-    """Takes a a list of subtable xds datasets and a dictionary of data
+) -> CASAVisSet:
+    """
+    Takes a a list of subtable xds datasets and a dictionary of data
     partition xds datasets and and packages them as a CASA vis dataset
     (cds)
 
-    :param partitions: data partiions as xds datasets
-    :param subtables: subtables as xds datasets
-    :param descr_add: substring to add to the short descr string of the cds
-    :return: A "cds" - container for the metainfo subtables and data partitions
+    Parameters
+    ----------
+    partitions : List[Tuple[str, xr.Dataset]]
+        data partiions as xds datasets
+    subtables : Dict[Any, xr.Dataset]
+        subtables as xds datasets
+    descr_add : str (Default value = "")
+        substring to add to the short descr string of the cds
+
+    Returns
+    -------
+    CASAVisSet
+        A "cds" - container for the metainfo subtables and data partitions
     """
     vers = version("xradio")
 
@@ -70,14 +92,24 @@ def vis_xds_packager_mxds(
     subtables: List[Tuple[str, xr.Dataset]],
     add_global_coords: bool = True,
 ) -> xr.Dataset:
-    """Takes a dictionary of data partition xds datasets and a list of
+    """
+    Takes a dictionary of data partition xds datasets and a list of
     subtable xds datasets and packages them as a dataset of datasets
     (mxds)
 
-    :param partitions: data partiions as xds datasets
-    :param subtables: subtables as xds datasets
-    :add_global_coords: whether to add coords to the output mxds
-    :return: A "mxds" - xr.dataset of datasets
+    Parameters
+    ----------
+    partitions : Dict[Any, xr.Dataset]
+        data partiions as xds datasets
+    subtables : List[Tuple[str, xr.Dataset]]
+        subtables as xds datasets
+        :add_global_coords: whether to add coords to the output mxds
+    add_global_coords: bool (Default value = True)
+
+    Returns
+    -------
+    xr.Dataset
+        A "mxds" - xr.dataset of datasets
     """
     mxds = xr.Dataset(attrs={"metainfo": subtables, "partitions": partitions})
 
@@ -125,6 +157,16 @@ def make_global_coords(mxds: xr.Dataset):
 def expand_xds(xds: xr.Dataset) -> xr.Dataset:
     """
     expand single (row) dimension of xds to (time, baseline)
+
+    Parameters
+    ----------
+    xds : xr.Dataset
+        "flat" dataset (with row dimension - without (time, baseline) dimensions)
+
+    Returns
+    -------
+    xr.Dataset
+        expanded dataset, with (time, baseline) dimensions
     """
     assert "baseline" not in xds.coords
 
@@ -160,6 +202,15 @@ def expand_xds(xds: xr.Dataset) -> xr.Dataset:
 def flatten_xds(xds: xr.Dataset) -> xr.Dataset:
     """
     flatten (time, baseline) dimensions of xds back to single dimension (row)
+
+    Parameters
+    ----------
+    xds : xr.Dataset
+
+
+    Returns
+    -------
+    xr.Dataset
     """
     nan_int = np.array([np.nan]).astype("int32")[0]
     txds = xds.copy()
@@ -188,21 +239,30 @@ def optimal_chunking(
     Determine the optimal chunk shape for reading an MS or Image based
     on machine resources and intended operations
 
-    :param ndim: number of dimensions to chunk. An MS is 3, an
-    expanded MS is 4. An image could be anywhere from 2 to 5. Not
-    needed if data_shape is given.
-    :param didxs: dimension indices over which subsequent operations
-    will be performed. Values should be less than ndim. Tries to
-    reduce inter-process communication of data contents. Needs to
-    know the shape to do this well. Default None balances chunk size
-    across all dimensions.
-    :param chunk_size: target chunk size ('large', 'small', 'auto').
-    Default 'auto' tries to guess by looking at CPU core count and
-    available memory.
-    :param data_shape: shape of the total MS DDI or Image data. Helps
-    to know. Default None does not optimize based on shape
+    Parameters
+    ----------
+    ndim : Union[int, None] = None
+        number of dimensions to chunk. An MS is 3, an
+        expanded MS is 4. An image could be anywhere from 2 to 5. Not
+        needed if data_shape is given.
+    didxs : Union[Tuple[int], List[int], None] = None
+        dimension indices over which subsequent operations
+        will be performed. Values should be less than ndim. Tries to
+        reduce inter-process communication of data contents. Needs to
+        know the shape to do this well. Default None balances chunk size
+        across all dimensions.
+    chunk_size : str (Default value = "auto")
+        target chunk size ('large', 'small', 'auto').
+        Default 'auto' tries to guess by looking at CPU core count and
+        available memory.
+    data_shape : Union[tuple, None] = None
+        shape of the total MS DDI or Image data. Helps
+        to know. Default None does not optimize based on shape
 
-    :return: optimal chunking for reading the ms (row, chan, pol)
+    Returns
+    -------
+    tuple
+        optimal chunking for reading the ms (row, chan, pol)
     """
     assert (ndim is not None) or (
         data_shape is not None
@@ -278,6 +338,21 @@ def calc_optimal_ms_chunk_shape(
     """
     Calculates the max number of rows (1st dim in shape) of a variable
     that can be fit in the memory for a thread.
+
+    Parameters
+    ----------
+    memory_available_in_bytes :
+
+    shape :
+
+    element_size_in_bytes :
+
+    column_name :
+
+
+    Returns
+    -------
+    int
     """
     factor = 0.8  # Account for memory used by other objects in thread.
     # total_mem = np.prod(shape)*element_size_in_bytes

--- a/src/xradio/vis/_vis_utils/_zarr/read.py
+++ b/src/xradio/vis/_vis_utils/_zarr/read.py
@@ -11,9 +11,16 @@ def read_part_keys(inpath: str) -> List[Tuple]:
     """
     Reads the partition keys from a Zarr-stored cds.
 
-    :param inpath: path to read from
+    Parameters
+    ----------
+    inpath : str
+        path to read from
 
-    :return: partition keys from a cds
+    Returns
+    -------
+    List[Tuple]
+        partition keys from a cds
+
     """
 
     xds_keys = xr.open_zarr(
@@ -31,9 +38,19 @@ def read_subtables(inpath: str, asdm_subtables: bool) -> Dict[str, xr.Dataset]:
     """
     Reads the metainfo subtables from a Zarr-stored cds.
 
-    :param inpath: path to read from
+    Parameters
+    ----------
+    inpath : str
+        path to read from
 
-    :return: metainfo subtables from a cds
+    asdm_subtables : bool
+
+
+    Returns
+    -------
+    Dict[str, xr.Dataset]
+        metainfo subtables from a cds
+
     """
 
     metainfo = {}
@@ -53,9 +70,18 @@ def read_partitions(inpath: str, part_keys: List[Tuple]) -> Dict[str, xr.Dataset
     """
     Reads all the data partitions a Zarr-stored cds.
 
-    :param inpath: path to read from
+    Parameters
+    ----------
+    inpath : str
+        path to read from
+    part_keys : List[Tuple]
 
-    :return: partitions from a cds
+
+    Returns
+    -------
+    Dict[str, xr.Dataset]
+        partitions from a cds
+
     """
 
     partitions = {}
@@ -79,13 +105,23 @@ def read_xds(
     """
     Read single xds from zarr storage.
 
-    :param inpath: path to read from
-    :param chunks: set chunk size per dimension. Dict is in the form of
-    'dim':chunk_size, for example {'time':100, 'baseline':400, 'chan':32, 'pol':1}.
-    Default None uses the original chunking in the zarr input.
-    :param consolidated: use zarr consolidated metadata.
-    :param overwrite_encoded_chunks: drop the zarr chunks encoded for each variable
-    when a dataset is loaded with specified chunk sizes.
+    Parameters
+    ----------
+    inpath : str
+        path to read from
+    chunks : Union[Dict, None] (Default value = None)
+        set chunk size per dimension. Dict is in the form of
+        'dim':chunk_size, for example {'time':100, 'baseline':400, 'chan':32, 'pol':1}.
+        Default None uses the original chunking in the zarr input.
+    consolidated : boold (Default value = True)
+        use zarr consolidated metadata.
+    overwrite_encoded_chunks : bool (Default value = True)
+        drop the zarr chunks encoded for each variable
+        when a dataset is loaded with specified chunk sizes.
+
+    Returns
+    -------
+    xr.Dataset
     """
 
     xds = xr.open_zarr(
@@ -99,11 +135,11 @@ def read_xds(
 
 
 def read_zarr(
-    infile,
-    sel_xds=None,
-    chunks=None,
-    consolidated=True,
-    overwrite_encoded_chunks=True,
+    infile: str,
+    sel_xds: Union[List, str] = None,
+    chunks: Dict = None,
+    consolidated: bool = True,
+    overwrite_encoded_chunks: bool = True,
     **kwargs,
 ):
     """
@@ -128,11 +164,12 @@ def read_zarr(
     overwrite_encoded_chunks : bool
         drop the zarr chunks encoded for each variable when a dataset is loaded with
         specified chunk sizes.  Default True, only applies when chunks is not None.
+    **kwargs :
+
 
     Returns
     -------
-    xarray.core.dataset.Dataset
-        New xarray Dataset of Visibility data contents
+
     """
 
     if chunks is None:

--- a/src/xradio/vis/_vis_utils/_zarr/write.py
+++ b/src/xradio/vis/_vis_utils/_zarr/write.py
@@ -10,10 +10,21 @@ import zarr
 def write_part_keys(
     partitions: Dict[Any, xr.Dataset], outpath: str, compressor: numcodecs.abc.Codec
 ) -> None:
-    """Writes an xds with the partition keys.
+    """
+    Writes an xds with the partition keys.
 
-    :param partitions: partitions from a cds
-    :param outpath: path to write a cds
+    Parameters
+    ----------
+    partitions : Dict[Any, xr.Dataset]
+        partitions from a cds
+    outpath : str
+        path to write a cds
+    compressor : numcodecs.abc.Codec
+        compressor used for the partition keys variable
+
+    Returns
+    -------
+
     """
 
     spw_ids, pol_setup_ids, intents = map(list, zip(*partitions.keys()))
@@ -47,6 +58,23 @@ def write_metainfo(
 ) -> None:
     """
     Write all metainfo subtables from a cds to zarr storage
+
+    Parameters
+    ----------
+    outpath : str
+
+    metainfo : Dict[str, xr.Dataset]:
+
+    chunks_on_disk : Union[Dict, None] (Default value = None)
+
+    compressor : Union[numcodecs.abc.Codec, None) (Default value = None)
+
+    consolidated : bool (Default value = True)
+
+
+    Returns
+    -------
+
     """
     metadir = Path(outpath, "metainfo")
     os.mkdir(metadir)
@@ -67,6 +95,23 @@ def write_partitions(
 ) -> None:
     """
     Write all data partitions metainfo from a cds to zarr storage
+
+    Parameters
+    ----------
+    outpath : str :
+
+    partitions : Dict[str, xr.Dataset]
+
+    chunks_on_disk : Union[Dict, None] (Default value = None)
+
+    compressor : Union[numcodecs.abc.Codec, None] (Default value = True)
+
+    consolidated: bool (Default value = True)
+
+
+    Returns
+    -------
+
     """
 
     partdir = Path(outpath, "partitions")
@@ -92,11 +137,28 @@ def write_xds_to_zarr(
     """
     Write one xr dataset from a cds (either metainfo or a partition).
 
-    :param xds: cds (sub)dataset
-    :param name: dataset name (example subtable name, or xds{i})
-    :param graph_name: the time taken to execute the graph and save the
-    dataset is measured and saved as an attribute in the zarr file.
-    The graph_name is the label for this timing information.
+    Parameters
+    ----------
+    xds : xr.Dataset
+        cds (sub)dataset
+    name : str
+        dataset name (example subtable name, or xds{i})
+    outpath: str :
+
+    chunks_on_disk : Union[Dict, None] (Default value = None)
+
+    compressor : Union[numcodecs.abc.Codec, None] (Default value = None)
+
+    consolidated : bool (Default value = True)
+
+    graph_name : str
+        the time taken to execute the graph and save the
+        dataset is measured and saved as an attribute in the zarr file.
+        The graph_name is the label for this timing information.
+
+    Returns
+    -------
+
     """
 
     xds_for_disk = xds
@@ -159,8 +221,20 @@ def write_xds_to_zarr(
 
 
 def prepare_attrs_for_zarr(name: str, xds: xr.Dataset) -> xr.Dataset:
-    """Deal with types that cannot be serialized as they are in the
+    """
+    Deal with types that cannot be serialized as they are in the
     cds/xds (ndarray etc.)
+
+    Parameters
+    ----------
+    name : str
+
+    xds : xr.Dataset
+
+
+    Returns
+    -------
+
     """
     ctds_attrs = xds.attrs["other"]["msv2"]["ctds_attrs"]
     col_descrs = ctds_attrs["column_descriptions"]

--- a/src/xradio/vis/_vis_utils/ms.py
+++ b/src/xradio/vis/_vis_utils/ms.py
@@ -24,7 +24,8 @@ def read_ms(
     expand: bool = False,
     **kwargs: str,
 ) -> CASAVisSet:
-    """Read a MeasurementSet (MSv2 format) into a next generation CASA
+    """
+    Read a MeasurementSet (MSv2 format) into a next generation CASA
     dataset (visibilities dataset as a set of Xarray datasets).
 
     The MS is partitioned into multiple sub- Xarray datasets (where the data variables are read as
@@ -33,28 +34,37 @@ def read_ms(
     and polarizations) and, subject to experimentation, by scan and subscan. This results in multiple
     partitions as xarray datasets (xds) contained within a main xds (mxds).
 
-    :param infile: Input MS filename
-    :param subtables: Also read and include subtables along with main table selection. Default False will
-    omit subtables (faster)
-    :param asdm_subtables: in addition to MeasurementSet subtables (if enabled), also read extension
-    subtables named "ASDM_*"
-    :param partition_scheme: (experimenting) Whether to partition sub-xds datasets by scan/subscan
-    (in addition to DDI), or other alternative partitioning schemes. Accepted values: 'scan/subscan',
-    'scan', 'ddi', 'intent'. Default: 'intent'
-    :param chunks: Can be used to set a specific chunk shape (with a tuple of ints), or to control the
-    optimization used for automatic chunking (with a list of ints). A tuple of ints in the form of (row,
-    chan, pol) will use a fixed chunk shape. A list or numpy array of ints in the form of [idx1, etc]
-    will trigger auto-chunking optimized for the given indices, with row=0, chan=1, pol=2. Default None
-    uses auto-chunking with a best fit across all dimensions (probably sub-optimal for most cases).
-    :param expand: (to be removed) Whether or not to return the original flat row structure of the MS (False)
-    or expand the rows to time x baseline dimensions (True). Expanding the rows allows for easier indexing
-    and parallelization across time and baseline dimensions, at the cost of some conversion time. Default
-    False
-    :param **kwargs: (to be removed?) Selection parameters from the standard way of making CASA MS
-    selections. Supported keys are: spw, field, scan, baseline, time, scanintent, uvdist, polarization,
-    array, observation.  Values are strings.
+    Parameters
+    ----------
+    infile : str
+        Input MS filename
+    subtables : bool (Default value = True)
+        Also read and include subtables along with main table selection. Default False will
+        omit subtables (faster)
+    asdm_subtables : bool (Default value = False)
+        in addition to MeasurementSet subtables (if enabled), also read extension
+        subtables named "ASDM_*"
+    partition_scheme : str (Default value = "intent")
+        experimenting) Whether to partition sub-xds datasets by scan/subscan
+        (in addition to DDI), or other alternative partitioning schemes. Accepted values: 'scan/subscan',
+        'scan', 'ddi', 'intent'. Default: 'intent'
+    chunks : Union[Tuple[int], List[int]] (Default value = None)
+        Can be used to set a specific chunk shape (with a tuple of ints), or to control the
+        optimization used for automatic chunking (with a list of ints). A tuple of ints in the form of (row,
+        chan, pol) will use a fixed chunk shape. A list or numpy array of ints in the form of [idx1, etc]
+        will trigger auto-chunking optimized for the given indices, with row=0, chan=1, pol=2. Default None
+        uses auto-chunking with a best fit across all dimensions (probably sub-optimal for most cases).
+    expand : bool (Default value = False)
+        to be removed) Whether or not to return the original flat row structure of the MS (False)
+        or expand the rows to time x baseline dimensions (True). Expanding the rows allows for easier indexing
+        and parallelization across time and baseline dimensions, at the cost of some conversion time.
+    **kwargs: str :
 
-    :return: Main xarray dataset of datasets for this visibility dataset
+
+    Returns
+    -------
+    CASAVisSet
+        Main xarray dataset of datasets for this visibility dataset
     """
 
     infile = os.path.expanduser(infile)
@@ -104,14 +114,23 @@ def load_vis_chunk(
     block_des: Dict[str, slice],
     partition_key: Tuple[int, int, str],
 ) -> Dict[Tuple[int, int], xr.Dataset]:
-    """Read a chunk of a MeasurementSet (MSv2 format) into an Xarray
+    """
+    Read a chunk of a MeasurementSet (MSv2 format) into an Xarray
     dataset, loading the data in memory.
 
-    :param infile: Input MS filename
-    :param block_des: specification of chunk to load
+    Parameters
+    ----------
+    infile : str
+        Input MS filename
+    block_des : Dict[str, slice]
+        specification of chunk to load
+    partition_key: partition_key: Tuple[int, int, str]
 
-    :return: Xarray datasets with chunk of visibility data, one per DDI
-    (spw_id, pol_setup_id pair)
+    Returns
+    -------
+    Dict[Tuple[int, int], xr.Dataset]
+        Xarray datasets with chunk of visibility data, one per DDI
+        (spw_id, pol_setup_id pair)
     """
     infile = os.path.expanduser(infile)
 

--- a/src/xradio/vis/_vis_utils/zarr.py
+++ b/src/xradio/vis/_vis_utils/zarr.py
@@ -11,13 +11,19 @@ from ._zarr.read import read_part_keys, read_partitions, read_subtables
 from ._zarr.write import write_metainfo, write_part_keys, write_partitions
 
 
-def is_zarr_vis(inpath) -> bool:
+def is_zarr_vis(inpath: str) -> bool:
     """
     Check if a given path has a visibilities dataset in Zarr format
 
-    :param inpath: path to a (possibly) Zarr vis dataset
+    Parameters
+    ----------
+    inpath : str
+        path to a (possibly) Zarr vis dataset
 
-    :return: whether zarr.open can open this path
+    Returns
+    -------
+    bool
+        whether zarr.open can open this path
     """
     try:
         with zarr.open(Path(inpath, "partition_keys"), mode="r"):
@@ -35,11 +41,19 @@ def read_vis(
     """
     Read a CASAVisSet stored in zarr format.
 
-    :param inpath: Input Zarr path
-    :param subtables: Also read and (metainformation) subtables along with main visibilities data.
-    :param asdm_subtables: Also read extension subtables named "ASDM_*"
+    Parameters
+    ----------
+    inpath : str
+        Input Zarr path
+    subtables : bool (Default value = True)
+        Also read and (metainformation) subtables along with main visibilities data.
+    asdm_subtables : bool (Default value = False)
+        Also read extension subtables named "ASDM_*"
 
-    :return: Main xarray dataset of datasets for this visibility dataset
+    Returns
+    -------
+    CASAVisSet
+        Main xarray dataset of datasets for this visibility dataset
     """
     inpath = os.path.expanduser(inpath)
     if not os.path.isdir(inpath):
@@ -71,25 +85,35 @@ def read_vis(
 
 
 def write_vis(
-    cds,
+    cds: CASAVisSet,
     outpath: str,
     chunks_on_disk: Union[Dict, None] = None,
     compressor: Union[numcodecs.abc.Codec, None] = None,
 ) -> None:
-    """Write CASA vis dataset to zarr format on disk. When
+    """
+    Write CASA vis dataset to zarr format on disk. When
     chunks_on_disk is not specified the chunking in the input dataset
     is used. When chunks_on_disk is specified that dataset is saved
     using that chunking.
 
-    :param cds: CASA visibilities dataset to write to disk
-    :param outpath: output path, generally ends in .zarr
-    :param chunks_on_disk: a dictionary with the chunk size that will
-    be used when writing to disk. For example {'time': 20, 'chan': 6}.
-    If chunks_on_disk is not specified the chunking of dataset will
-    be used.
-    :param compressor: the blosc compressor to use when saving the
-    converted data to disk using zarr. If None the zstd compression
-    algorithm used with compression level 2.
+    Parameters
+    ----------
+    cds : CASAVisSet
+        CASA visibilities dataset to write to disk
+    outpath : str
+        output path, generally ends in .zarr
+    chunks_on_disk : Union[Dict, None] = None (Default value = None)
+        a dictionary with the chunk size that will
+        be used when writing to disk. For example {'time': 20, 'chan': 6}.
+        If chunks_on_disk is not specified the chunking of dataset will
+        be used.
+    compressor : Union[numcodecs.abc.Codec, None] (Default value = None)
+        the blosc compressor to use when saving the
+        converted data to disk using zarr. If None the zstd compression
+        algorithm used with compression level 2.
+
+    Returns
+    -------
     """
 
     if compressor is None:

--- a/src/xradio/vis/vis_io.py
+++ b/src/xradio/vis/vis_io.py
@@ -15,7 +15,8 @@ def read_vis(
     chunks: Union[Tuple[int], List[int]] = None,
     expand: bool = False,
 ) -> CASAVisSet:
-    """Read a MeasurementSet (MSv2 format) into a next generation CASA
+    """
+    Read a MeasurementSet (MSv2 format) into a next generation CASA
     dataset (visibilities dataset as a set of Xarray datasets).
 
     The MS is partitioned into multiple sub- Xarray datasets (where the data variables are read as
@@ -24,31 +25,37 @@ def read_vis(
     and polarizations) and, subject to experimentation, by scan and subscan. This results in multiple
     partitions as xarray datasets (xds) contained within a main xds (mxds).
 
-    :param infile: Input MS filename
-    :param rowmap: (to be removed) Dictionary of DDI to tuple of (row indices, channel indices). Returned
-    by ms_selection function. Default None ignores selections
-    :param subtables: Also read and include subtables along with main table selection. Default False will
-    omit subtables (faster)
-    :param asdm_subtables: in addition to MeasurementSet subtables (if enabled), also read extension
-    subtables names "ASDM_*"
-    :param partition_scheme: (experimenting) Whether to partition sub-xds datasets by scan/subscan
-    (in addition to DDI), or other alternative partitioning schemes. Accepted values: 'scan/subscan',
-    'scan', 'ddi', 'intent'. Default: 'intent'
-    :param chunks: Can be used to set a specific chunk shape (with a tuple of ints), or to control the
-    optimization used for automatic chunking (with a list of ints). A tuple of ints in the form of (row,
-    chan, pol) will use a fixed chunk shape. A list or numpy array of ints in the form of [idx1, etc]
-    will trigger auto-chunking optimized for the given indices, with row=0, chan=1, pol=2. Default None
-    uses auto-chunking with a best fit across all dimensions (probably sub-optimal for most cases).
-    :param expand: (to be removed) Whether or not to return the original flat row structure of the MS (False)
-    or expand the rows to time x baseline dimensions (True). Expanding the rows allows for easier indexing
-    and parallelization across time and baseline dimensions, at the cost of some conversion time. Default
-    False
-    :param **kwargs: (to be removed?) Selection parameters from the standard way of making CASA MS
-    selections. Supported keys are: spw, field, scan, baseline, time, scanintent, uvdist, polarization,
-    array, observation.  Values are strings.
+    Parameters
+    ----------
+    infile : str
+        Input MS filename
+    subtables : bool (Default value = True)
+        Also read and include subtables along with main table selection. Default False will
+        omit subtables (faster)
+    asdm_subtables : bool (Default value = True)
+        in addition to MeasurementSet subtables (if enabled), also read extension
+        subtables names "ASDM_*"
+    partition_scheme : str (Default value = "intent")
+        (experimenting) Whether to partition sub-xds datasets by scan/subscan
+        (in addition to DDI), or other alternative partitioning schemes. Accepted values: 'scan/subscan',
+        'scan', 'ddi', 'intent'. Default: 'intent'
+    chunks : Union[Tuple[int], List[int]] (Default value = None)
+        Can be used to set a specific chunk shape (with a tuple of ints), or to control the
+        optimization used for automatic chunking (with a list of ints). A tuple of ints in the form of (row,
+        chan, pol) will use a fixed chunk shape. A list or numpy array of ints in the form of [idx1, etc]
+        will trigger auto-chunking optimized for the given indices, with row=0, chan=1, pol=2. Default None
+        uses auto-chunking with a best fit across all dimensions (probably sub-optimal for most cases).
+    expand : bool (Default value = False)
+        (to be removed) Whether or not to return the original flat row structure of the MS (False)
+        or expand the rows to time x baseline dimensions (True). Expanding the rows allows for easier indexing
+        and parallelization across time and baseline dimensions, at the cost of some conversion time. Default
+        False
 
-    :return: ngCASA visisbilities dataset, essentially made of two dictionaries of
-    metainformation and data partitions
+    Returns
+    -------
+    CASAVisSet
+        ngCASA visisbilities dataset, essentially made of two dictionaries of
+        metainformation and data partitions
     """
     infile = os.path.expanduser(infile)
     if not os.path.isdir(infile):
@@ -68,16 +75,28 @@ def load_vis_block(
     partition_key: Tuple[int, int, str],
     subtables: List[str] = None,
 ) -> Dict[Tuple[int, int], xr.Dataset]:
-    """Read a chunk of a visibilities dataset into an Xarray dataset, loading the
+    """
+    Read a chunk of a visibilities dataset into an Xarray dataset, loading the
     data in memory.
     The input format support is the MeasurementSet v2 (MSv2 format)
 
-    :param infile: Input visibilities path
-    :param block_des: specification of chunk to load
+    Parameters
+    ----------
+    infile : str
+        Input visibilities path
+    block_des : Dict[str, slice]
+        specification of chunk to load
+    partition_key: Tuple[int, int, str]
+        key of partition to load
+    subtables: List[str] (Default value = None)
+        subtables to load
 
-    :return: CASA visibilities dataset holding a chunk of visibility data, for one
-    partition
-    (spw_id, pol_setup_id, intent_string triplet)
+    Returns
+    -------
+    Dict[Tuple[int, int], xr.Dataset]
+        CASA visibilities dataset holding a chunk of visibility data, for one
+        partition
+        (spw_id, pol_setup_id, intent_string triplet)
     """
     # TODO: use the input partition_key
     # the intent str of the partition_key is not yet effectively used
@@ -92,20 +111,33 @@ def write_vis(
     compressor: Union[numcodecs.abc.Codec, None] = None,
     out_format: str = "zarr",
 ) -> None:
-    """Write CASA vis dataset to disk.
+    """
+    Write CASA vis dataset to disk.
     The disk format supported is "zarr". When chunks_on_disk is not specified the
     chunking in the input dataset is used. When chunks_on_disk is specified that
     dataset is saved using that chunking.
 
-    :param cds: CASA visibilities dataset to write to disk
-    :param outpath: output path, generally ends in .zarr
-    :param chunks_on_disk: a dictionary with the chunk size that will
-    be used when writing to disk. For example {'time': 20, 'chan': 6}.
-    If chunks_on_disk is not specified the chunking of dataset will
-    be used.
-    :param compressor: the blosc compressor to use when saving the
-    converted data to disk using zarr. If None the zstd compression
-    algorithm used with compression level 2.
+    Parameters
+    ----------
+    cds : CASAVisSet
+        CASA visibilities dataset to write to disk
+    outpath : str
+        output path, generally ends in .zarr
+    chunks_on_disk : Union[Dict, None] (Default value = None)
+        a dictionary with the chunk size that will
+        be used when writing to disk. For example {'time': 20, 'chan': 6}.
+        If chunks_on_disk is not specified the chunking of dataset will
+        be used.
+    compressor : Union[numcodecs.abc.Codec, None] (Default value = None)
+        the blosc compressor to use when saving the
+        converted data to disk using zarr. If None the zstd compression
+        algorithm used with compression level 2.
+    out_format : str (Default value = "zarr")
+        format to write
+
+    Returns
+    -------
+    None
     """
 
     if out_format == "zarr":


### PR DESCRIPTION
This is an uneventful PR. It simply converts the docstring syntax, from the old reST to numpy style in src/vis.
I run `pyment` and then corrected manually a few formatting issues plus a few small bugs in the docs that came up in the process. Finally run black on the files changed to catch up with the changes in some type annotations.  

Note for the future: in these changes, the types of parameter/returns are included in the docstrings. But for the future I'd favor not including types manually in the docstrings. I think it would be easier to maintain if we use the types directly from the type hints via extensions (for our case `[sphinx-autodoc-napoleon-typehints](https://pypi.org/project/sphinx-autodoc-napoleon-typehints)). This way we can get the types auto-populated in the documentation from the type hints, avoiding duplication (and also avoiding relying on doc text which would tend to be less dependable than type hints).

About `pyment`, `docconvert` was a bit more reliable but it doesn't seem to handle types from the annotations.

 ---
Note well:
```
This contribution is made under the current ALMA software agreements.
(c) European Southern Observatory, 2024
Copyright by ESO (in the framework of the ALMA collaboration)
```