### PR TITLE
Add unit tests for vis/_vis_utils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,15 @@ docs = [
     'twine',
     'pandoc'
 ]
+
+[tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+    "--strict-markers"
+]
+testpaths = [
+    "tests"
+]
+pythonpath = [
+    "."
+]

--- a/src/xradio/vis/_vis_utils/_ms/_tables/read.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read.py
@@ -13,7 +13,7 @@ from casacore import tables
 
 from .table_query import open_query, open_table_ro
 
-CASACORE_TO_PD_TIME_CORRECTION = 3506716800.0
+CASACORE_TO_PD_TIME_CORRECTION = 3_506_716_800.0
 SECS_IN_DAY = 86400
 
 
@@ -21,7 +21,7 @@ def table_exists(path: str) -> bool:
     return tables.tableexists(path)
 
 
-def convert_casacore_time(rawtimes: np.ndarray, convert_to_datetime=True) -> np.ndarray:
+def convert_casacore_time(rawtimes: np.ndarray) -> np.ndarray:
     """
     Read time columns to datetime format
     pandas datetimes are referenced against a 0 of 1970-01-01
@@ -33,12 +33,9 @@ def convert_casacore_time(rawtimes: np.ndarray, convert_to_datetime=True) -> np.
     :return: times converted to pandas reference
     """
 
-    if convert_to_datetime:
-        return pd.to_datetime(
-            np.array(rawtimes) - CASACORE_TO_PD_TIME_CORRECTION, unit="s"
-        ).values
-    else:
-        return np.array(rawtimes) - CASACORE_TO_PD_TIME_CORRECTION
+    return pd.to_datetime(
+        np.array(rawtimes) - CASACORE_TO_PD_TIME_CORRECTION, unit="s"
+    ).values
     # dt = pd.to_datetime(np.atleast_1d(rawtimes) - correction, unit='s').values
     # if len(np.array(rawtimes).shape) == 0: dt = dt[0]
     # return dt
@@ -350,7 +347,7 @@ def read_generic_table(
             logger.debug(f"table is empty: {inpath} {tname}")
             return xr.Dataset(attrs=attrs)
 
-        taql_gtable = f"select * from $gtable {taql_where}"
+        taql_gtable = f"select * from $gtable {taql_where or ''}"
         with open_query(gtable, taql_gtable) as tb_tool:
             if tb_tool.nrows() == 0:
                 logger.debug(
@@ -626,7 +623,8 @@ def raw_col_data_to_coords_vars(
                 data = convert_casacore_time(data)
             except pd.errors.OutOfBoundsDatetime as exc:
                 if inpath.endswith("WEATHER"):
-                    logger.error(
+                    # intentionally not callling logging.exception
+                    logger.warning(
                         f"Exception when converting WEATHER/TIME: {exc}. TIME data: {data}"
                     )
                 else:
@@ -689,9 +687,11 @@ def handle_variable_col_issues(
         data = np.stack(
             [
                 np.pad(
-                    row[col]
-                    if len(row[col]) > 0
-                    else np.array(row[col]).reshape(np.arange(len(mshape)) * 0),
+                    (
+                        row[col]
+                        if len(row[col]) > 0
+                        else np.array(row[col]).reshape(np.arange(len(mshape)) * 0)
+                    ),
                     [(0, ss) for ss in mshape - np.array(row[col]).shape],
                     "constant",
                     constant_values=pad_nan,

--- a/src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
@@ -74,12 +74,14 @@ def redim_id_data_vars(mvars: Dict[str, xr.DataArray]) -> Dict[str, xr.DataArray
         "state_id",
     ]
     for vname in var_names:
-        mvars[vname] = mvars[vname].sel(baseline=0, drop=True)
+        if "baseline" in mvars[vname].coords:
+            mvars[vname] = mvars[vname].sel(baseline=0, drop=True)
 
     for idx in ["1", "2"]:
         new_name = f"baseline_ant{idx}_id"
         mvars[new_name] = mvars.pop(f"antenna{idx}_id")
-        mvars[new_name] = mvars[new_name].sel(time=0, drop=True)
+        if "time" in mvars[new_name].coords:
+            mvars[new_name] = mvars[new_name].sel(time=0, drop=True)
 
     return mvars
 
@@ -501,7 +503,7 @@ def read_flat_main_table(
         # we keep this read_flat functionality
         _scans, states = scan_state
         # get row indices relative to full main table
-        if states:
+        if states is not None:
             taql_where += (
                 f" AND SCAN_NUMBER = {scan_state[0]} AND STATE_ID = {scan_state[1]}"
             )
@@ -517,11 +519,10 @@ def read_flat_main_table(
         taql_rowid = f"select rowid() as ROWS from $mtable {taql_where}"
         with open_query(mtable, taql_rowid) as query_rows:
             rowidxs = query_rows.getcol("ROWS")
-            mtable.close()
 
     nrows = len(rowidxs)
     if nrows == 0:
-        return xr.Dataset()
+        return xr.Dataset(), {}, {}
 
     part_ids = get_partition_ids(mtable, taql_where)
 
@@ -539,7 +540,7 @@ def read_flat_main_table(
                 (col, query_cols.getcol(col, 0, 1))
                 for col in cols
                 if (col not in ignore)
-                and (ignore_msv2_cols and (col not in ignore_msv2_cols))
+                and not (ignore_msv2_cols and col in ignore_msv2_cols)
             ]
         )
         chan_cnt, pol_cnt = [
@@ -637,7 +638,7 @@ def read_flat_main_table(
             )
 
     mvars["time"] = xr.DataArray(
-        convert_casacore_time(mvars["TIME"].values), dims=["row"]
+        convert_casacore_time(mvars["time"].values), dims=["row"]
     ).chunk({"row": chunks[0]})
 
     # add xds global attributes

--- a/src/xradio/vis/_vis_utils/_ms/_tables/read_subtables.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read_subtables.py
@@ -42,7 +42,7 @@ def read_ephemerides(
         logger.debug(f"Reading ephemerides info from: FIELD / {sdir.name}")
         # One "EPHEM_*.tab" (each with a difference ephemeris_id) to concatenate
         ephem.append(
-            read_generic_table(infile, str(Path("field", sdir)), timecols=["MJD"])
+            read_generic_table(infile, str(Path(*sdir.parts[-2:])), timecols=["MJD"])
         )
 
     if ephem:

--- a/src/xradio/vis/_vis_utils/_ms/_tables/write_exp_api.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/write_exp_api.py
@@ -1,15 +1,46 @@
 import os, time
-from typing import Optional
+from typing import List, Optional
 
 import dask
 import numpy as np
-
+import xarray as xr
 
 from ..._utils.xds_helper import flatten_xds, calc_optimal_ms_chunk_shape
 from .write import write_generic_table, write_main_table_slice
 from .write import create_table, revert_time
 
 from casacore import tables
+
+
+# TODO: this should be consolidated with the equivalent in read_main_table,
+# if we keep this mapping
+rename_to_msv2_cols = {
+    "antenna1_id": "antenna1",
+    "antenna2_id": "antenna2",
+    "feed1_id": "feed1",
+    "feed2_id": "feed2",
+    # optional cols:
+    # "weight": "weight_spectrum",
+    "vis_corrected": "corrected_data",
+    "vis": "data",
+    "vis_model": "model_data",
+    "autocorr": "float_data",
+}
+# cols added in xds not in MSv2
+cols_not_in_msv2 = ["baseline_ant1_id", "baseline_ant2_id"]
+
+
+def cols_from_xds_to_ms(cols: List[str]) -> List[str]:
+    """
+    Translates between lowercase/uppercase convention
+    Rename some MS_colum_names <-> xds_data_var_names
+    Excludes the pointing_ vars that are in the xds but should not be written to MS
+    """
+    return {
+        rename_to_msv2_cols.get(col, col).upper(): col
+        for col in cols
+        if (col and col not in cols_not_in_msv2 and not col.startswith("pointing_"))
+    }
 
 
 def write_ms(
@@ -51,13 +82,13 @@ def write_ms(
         print("initializing output...")
     start = time.time()
 
-    xds_list = [
-        flatten_xds(mxds.attrs[kk]) for kk in mxds.attrs if kk.startswith("xds")
-    ]
-    cols = list(set([dv for dx in xds_list for dv in dx.data_vars]))
+    xds_list = [flatten_xds(xds) for _key, xds in mxds.partitions.items()]
+
+    cols = cols_from_xds_to_ms(
+        list(set([dv for dx in xds_list for dv in dx.data_vars]))
+    )
     if modcols is None:
         modcols = cols
-    modcols = list(np.atleast_1d(modcols))
 
     # create an empty main table with enough space for all desired xds partitions
     # the first selected xds partition will be passed to create_table to provide a definition of columns and table keywords
@@ -71,37 +102,42 @@ def write_ms(
     # the SPECTRAL_WINDOW, POLARIZATION, and DATA_DESCRIPTION tables must always be present and will always be written
     delayed_writes = [
         dask.delayed(write_generic_table)(
-            mxds.SPECTRAL_WINDOW, outfile, "SPECTRAL_WINDOW", cols=None
+            mxds.metainfo["spectral_window"], outfile, "SPECTRAL_WINDOW", cols=None
         )
     ]
     delayed_writes += [
         dask.delayed(write_generic_table)(
-            mxds.POLARIZATION, outfile, "POLARIZATION", cols=None
+            mxds.metainfo["polarization"], outfile, "POLARIZATION", cols=None
         )
     ]
-    delayed_writes += [
-        dask.delayed(write_generic_table)(
-            mxds.DATA_DESCRIPTION, outfile, "DATA_DESCRIPTION", cols=None
-        )
-    ]
+    # should data_description be kept somewhere (in attrs?) or rebuilt?
+    # delayed_writes += [
+    #     dask.delayed(write_generic_table)(
+    #         mxds.metainfo["data_description"], outfile, "DATA_DESCRIPTION", cols=None
+    #     )
+    # ]
     if subtables:  # also write the rest of the subtables
         for subtable in list(mxds.attrs.keys()):
-            if subtable.startswith("xds") or (
-                subtable in ["SPECTRAL_WINDOW", "POLARIZATION", "DATA_DESCRIPTION"]
+            if (
+                subtable.startswith("xds")
+                or (subtable in ["spectral_window", "polarization", "data_description"])
+                or not isinstance(subtable, xr.Dataset)
             ):
                 continue
+
             if verbose:
                 print("writing subtable %s..." % subtable)
             delayed_writes += [
                 dask.delayed(write_generic_table)(
-                    mxds.attrs[subtable], outfile, subtable, cols=None, verbose=verbose
+                    mxds.attrs[subtable], outfile, subtable, cols=None
                 )
             ]
 
     ddi_row_start = 0  # output rows will be ordered by DDI
     for xds in xds_list:
         txds = xds.copy().unify_chunks()
-        ddi = txds.data_desc_id[:1].values[0]
+        # TODO: carry over or rebuild?
+        ddi = 0  # txds.data_desc_id[:1].values[0]
 
         # serial write entire DDI column first so subsequent delayed writes can find their spot
         if verbose:
@@ -111,6 +147,10 @@ def write_ms(
         for col in modcols:
             if col not in txds:
                 continue  # this can happen with bad_cols, should still be created in create_table()
+
+            if col in cols_not_in_msv2:
+                continue
+
             chunks = txds[col].chunks
             dims = txds[col].dims
             for d0 in range(len(chunks[0])):
@@ -161,9 +201,13 @@ def write_ms(
         max_chunk_size = np.prod(
             [txds.chunks[kk][0] for kk in txds.chunks if kk in ["row", "freq", "pol"]]
         )
-        for col in list(np.setdiff1d(cols, modcols)):
+        for col in list(np.setdiff1d(list(cols), modcols)):
             if col not in txds:
                 continue  # this can happen with bad_cols, should still be created in create_table()
+
+            if col in cols_not_in_msv2:
+                continue
+
             col_chunk_size = np.prod([kk[0] for kk in txds[col].chunks])
             col_rows = (
                 int(np.ceil(max_chunk_size / col_chunk_size)) * txds[col].chunks[0][0]
@@ -175,7 +219,7 @@ def write_ms(
                         txda,
                         outfile,
                         ddi=ddi,
-                        col=col,
+                        col=rename_to_msv2_cols.get(col, col).upper(),
                         full_shape=txda.shape[1:],
                         starts=(rr + ddi_row_start,) + (0,) * (len(txda.shape) - 1),
                     )
@@ -239,11 +283,9 @@ def write_ms_serial(
         print("initializing output...")
     # start = time.time()
 
-    xds_list = [
-        flatten_xds(mxds.attrs[kk]) for kk in mxds.attrs if kk.startswith("xds")
-    ]
+    xds_list = [flatten_xds(xds) for _key, xds in mxds.partitions.items()]
     cols = list(set([dv for dx in xds_list for dv in dx.data_vars]))
-    cols = list(np.atleast_1d(cols))
+    cols = cols_from_xds_to_ms(list(np.atleast_1d(cols)))
 
     # create an empty main table with enough space for all desired xds partitions
     # the first selected xds partition will be passed to create_table to provide a definition of columns and table keywords
@@ -255,9 +297,14 @@ def write_ms_serial(
 
     # start a list of dask delayed writes to disk (to be executed later)
     # the SPECTRAL_WINDOW, POLARIZATION, and DATA_DESCRIPTION tables must always be present and will always be written
-    write_generic_table(mxds.SPECTRAL_WINDOW, outfile, "SPECTRAL_WINDOW", cols=None)
-    write_generic_table(mxds.POLARIZATION, outfile, "POLARIZATION", cols=None)
-    write_generic_table(mxds.DATA_DESCRIPTION, outfile, "DATA_DESCRIPTION", cols=None)
+    write_generic_table(
+        mxds.metainfo["spectral_window"], outfile, "SPECTRAL_WINDOW", cols=None
+    )
+    write_generic_table(
+        mxds.metainfo["polarization"], outfile, "POLARIZATION", cols=None
+    )
+    # should data_description be kept somewhere (in attrs?) or rebuilt?
+    # write_generic_table(mxds.metainfo.data_description, outfile, "DATA_DESCRIPTION", cols=None)
 
     if subtables:  # also write the rest of the subtables
         # for subtable in list(mxds.attrs.keys()):
@@ -266,20 +313,24 @@ def write_ms_serial(
         # ['FEED','FIELD','ANTENNA','HISTORY']
         # ,'FIELD','ANTENNA'
         # for subtable in ['OBSERVATION']:
-        for subtable in list(mxds.attrs.keys()):
+        for subtable in list(mxds.metainfo.keys()):
             if subtable.startswith("xds") or (
-                subtable in ["SPECTRAL_WINDOW", "POLARIZATION", "DATA_DESCRIPTION"]
+                subtable in ["spectral_window", "polarization", "data_description"]
             ):
                 continue
             if verbose:
                 print("writing subtable %s..." % subtable)
             # print(subtable)
             # print(mxds.attrs[subtable])
-            write_generic_table(
-                mxds.attrs[subtable], outfile, subtable, cols=None, verbose=verbose
-            )
+            try:
+                write_generic_table(
+                    mxds.metainfo[subtable], outfile, subtable.upper(), cols=None
+                )
+            except (RuntimeError, KeyError) as exc:
+                print(f"Exception writing subtable {subtable}: {exc}")
 
-    vis_data_shape = mxds.xds0.data.shape
+    part_key0 = next(iter(mxds.partitions))
+    vis_data_shape = mxds.partitions[part_key0].vis.shape
     rows_chunk_size = calc_optimal_ms_chunk_shape(
         memory_available_in_bytes, vis_data_shape, 16, "DATA"
     )
@@ -292,8 +343,8 @@ def write_ms_serial(
     )
 
     start_main = time.time()
-    for col in cols:
-        xda = mxds.xds0[col]
+    for col, var_name in cols.items():
+        xda = mxds.partitions[part_key0][var_name]
         # print(col,xda.dtype)
 
         for start_row in np.arange(0, vis_data_shape[0], rows_chunk_size):
@@ -308,8 +359,11 @@ def write_ms_serial(
             # print('1. Time', time.time()-start, values.shape)
 
             # start = time.time()
-            tbs.putcol(col, values, start_row, len(values))
-            # print('2. Time', time.time()-start)
+            try:
+                tbs.putcol(col, values, start_row, len(values))
+                # print('2. Time', time.time()-start)
+            except RuntimeError as exc:
+                print(f"Exception writing main table column {col}: {exc}")
 
     print("3. Time", time.time() - start_main)
 

--- a/src/xradio/vis/_vis_utils/_ms/chunks.py
+++ b/src/xradio/vis/_vis_utils/_ms/chunks.py
@@ -115,6 +115,10 @@ def finalize_chunks(
         rename_ids=subt_rename_ids.get(pnt_name, None),
         time_slice=time_slice,
     )
+
+    if "time" not in pnt_xds.dims:
+        return xr.Dataset()
+
     pnt_xds = pnt_xds.compute()
 
     pnt_chunks = {

--- a/src/xradio/vis/_vis_utils/_ms/descr.py
+++ b/src/xradio/vis/_vis_utils/_ms/descr.py
@@ -38,18 +38,22 @@ def describe_ms(
 
     ddi_xds = read_generic_table(infile, "DATA_DESCRIPTION")
     ddis = list(ddi_xds.row.values) if rowmap is None else list(rowmap.keys())
-
     summary: Union[pd.DataFrame, Dict] = []
     if mode == "summary":
         summary = pd.DataFrame([])
 
+    all_sdf = []
     with open_table_ro(infile) as tb_tool:
         for ddi in ddis:
             taql = f"select * from $tb_tool where DATA_DESC_ID = {ddi}"
             with open_query(tb_tool, taql) as query_per_ddi:
-                populate_ms_descr(infile, mode, query_per_ddi, summary, ddi, ddi_xds)
+                sdf = populate_ms_descr(
+                    infile, mode, query_per_ddi, summary, ddi, ddi_xds
+                )
+                all_sdf.append(sdf)
 
     if mode == "summary":
+        summary = pd.DataFrame(all_sdf)
         summary = summary.set_index("ddi").sort_index()
     else:
         summary = dict(summary)

--- a/src/xradio/vis/_vis_utils/_ms/partition_queries.py
+++ b/src/xradio/vis/_vis_utils/_ms/partition_queries.py
@@ -159,7 +159,8 @@ def filter_intents_per_ddi(
     every_intent = intents.split(",")
     filtered_intents = []
     for ddi in ddis:
-        spw_name = spw_name_by_ddi[ddi]
+        spw_name = spw_name_by_ddi.get(ddi, "")
+
         if not spw_name:
             # we cannot say / cannot filter
             filtered_intents.append(intents)

--- a/src/xradio/vis/_vis_utils/_ms/partitions.py
+++ b/src/xradio/vis/_vis_utils/_ms/partitions.py
@@ -140,13 +140,15 @@ def read_ms_scan_subscan_partitions(
         if partition_scheme == "intent":
             intent = distinct_intents[cnt]
             cnt += 1
+        else:
+            intent = ""
 
         if partition_scheme == "scan":
             scan_state = (scan, None)
         else:
             scan_state = (scan, state)
         # experimenting, comparing overheads of expanded vs. flat
-        expanded = True
+        expanded = not expand
         if expanded:
             xds, part_ids, attrs = read_expanded_main_table(
                 infile, ddi, scan_state=scan_state, ignore_msv2_cols=ignore_msv2_cols
@@ -263,7 +265,7 @@ def read_ms_ddi_partitions(
         )
 
         # experimenting, comparing overheads of expanded vs. flat
-        expanded = True
+        expanded = not expand
         if expanded:
             xds, part_ids, attrs = read_expanded_main_table(
                 infile, ddi, ignore_msv2_cols=ignore_msv2_cols

--- a/src/xradio/vis/_vis_utils/_ms/subtables.py
+++ b/src/xradio/vis/_vis_utils/_ms/subtables.py
@@ -17,7 +17,7 @@ subt_rename_ids = {
     "FIELD": {"row": "field_id", "dim_1": "poly_id", "dim_2": "ra/dec"},
     "FREQ_OFFSET": {"antenna1": "antenna1_id", "antenna2": "antenna2_id"},
     "OBSERVATION": {"row": "observation_id", "dim_1": "start/end"},
-    "POINTING": {"dim_1": "n_polynomial", "dim_2": "dir", "dim_3": "dir"},
+    "POINTING": {"dim_1": "n_polynomial", "dim_3": "dir"},
     "POLARIZATION": {"row": "pol_setup_id", "dim_2": "product_id"},
     "PROCESSOR": {"row": "processor_id"},
     "SPECTRAL_WINDOW": {"row": "spectral_window_id", "dim_1": "chan"},

--- a/src/xradio/vis/_vis_utils/_utils/xds_helper.py
+++ b/src/xradio/vis/_vis_utils/_utils/xds_helper.py
@@ -87,7 +87,7 @@ def vis_xds_packager_mxds(
     return mxds
 
 
-def make_global_coords(mxds: xr.Dataset):
+def make_global_coords(mxds: xr.Dataset) -> Dict[str, xr.DataArray]:
     coords = {}
     metainfo = mxds.attrs["metainfo"]
     if "antenna" in metainfo:
@@ -130,7 +130,9 @@ def expand_xds(xds: xr.Dataset) -> xr.Dataset:
 
     txds = xds.copy()
     unique_baselines, baselines = np.unique(
-        [txds.antenna1.values, txds.antenna2.values], axis=1, return_inverse=True
+        [txds.baseline_ant1_id.values, txds.baseline_ant2_id.values],
+        axis=1,
+        return_inverse=True,
     )
     txds["baseline"] = xr.DataArray(baselines.astype("int32"), dims=["row"])
 
@@ -167,8 +169,11 @@ def flatten_xds(xds: xr.Dataset) -> xr.Dataset:
     # flatten the time x baseline dimensions of main table
     if ("time" in xds.sizes) and ("baseline" in xds.sizes):
         txds = xds.stack({"row": ("time", "baseline")}).transpose("row", ...)
+        # compute for issue https://github.com/hainegroup/oceanspy/issues/332
+        # drop=True silently does compute (or at least used to)
         txds = txds.where(
-            (txds.state_id != nan_int) & (txds.field_id != nan_int), drop=True
+            ((txds.state_id != nan_int) & (txds.field_id != nan_int)).compute(),
+            drop=True,
         )  # .unify_chunks()
         for dv in list(xds.data_vars):
             txds[dv] = txds[dv].astype(xds[dv].dtype)
@@ -283,17 +288,13 @@ def calc_optimal_ms_chunk_shape(
     # total_mem = np.prod(shape)*element_size_in_bytes
     single_row_mem = np.prod(shape[1:]) * element_size_in_bytes
 
-    try:
-        assert single_row_mem < factor * memory_available_in_bytes
-    except AssertionError as err:
-        logger.exception(
+    if not single_row_mem < factor * memory_available_in_bytes:
+        msg = (
             "Not engough memory in a thread to contain a row of "
-            + column_name
-            + ". Need at least "
-            + str(single_row_mem / factor)
-            + " bytes."
+            f"{column_name}. Need at least {single_row_mem / factor}"
+            " bytes."
         )
-        raise err
+        raise RuntimeError(msg)
 
     rows_chunk_size = int((factor * memory_available_in_bytes) / single_row_mem)
 

--- a/src/xradio/vis/_vis_utils/_zarr/read.py
+++ b/src/xradio/vis/_vis_utils/_zarr/read.py
@@ -178,8 +178,9 @@ def read_zarr(
 
 
 def _fix_dict_for_ms(name, xds):
-    xds.attrs["column_descriptions"] = xds.attrs["column_descriptions"][0]
-    xds.attrs["info"] = xds.attrs["info"][0]
+    # Used to be:
+    # xds.attrs["column_descriptions"] = xds.attrs["column_descriptions"][0]
+    # xds.attrs["info"] = xds.attrs["info"][0]
 
     if "xds" in name:
         xds.column_descriptions["UVW"]["shape"] = np.array(

--- a/src/xradio/vis/_vis_utils/zarr.py
+++ b/src/xradio/vis/_vis_utils/zarr.py
@@ -59,7 +59,7 @@ def read_vis(
     all_time = time.time() - all_start
     logger.info(f"Time to read dataset from_zarr {inpath}: {all_time}")
 
-    vers = xradio.__version__
+    vers = "version-WIP"
     descr_add = "read_vis from zarr"
     cds = CASAVisSet(
         metainfo=metainfo,

--- a/tests/unit/vis/_vis_utils/_ms/_tables/test_read.py
+++ b/tests/unit/vis/_vis_utils/_ms/_tables/test_read.py
@@ -1,0 +1,300 @@
+import pytest
+
+import numpy as np
+from pathlib import Path
+
+@pytest.mark.parametrize(
+    "tab_name, expected_result",
+    [
+        ("ms_minimal_required", True),
+        ("ms_tab_nonexistent", False),
+        ("ddi_xds_min", False),
+    ],
+)
+def test_table_exists(tab_name, expected_result, request):
+    from xradio.vis._vis_utils._ms._tables.read import table_exists
+
+    fixture = request.getfixturevalue(tab_name)
+    fname = fixture.fname if isinstance(fixture, tuple) else fixture
+    assert table_exists(fname) == expected_result
+
+
+@pytest.mark.parametrize(
+    "times, expected_result",
+    [
+        (
+            np.array([0, 1_900_000_000.36]),
+            np.array(
+                ["1858-11-17T00:00:00.0", "1919-02-01T17:46:40.360"],
+                dtype="datetime64[ns]",
+            ),
+        ),
+        (np.array([10]), np.array([], dtype="datetime64[ns]")),
+        (
+            np.array([5_000_000_000.1234]),
+            np.array(["2017-04-27T08:53:20.123399680"], dtype="datetime64[ns]"),
+        ),
+        (
+            np.array([10_000_000_000]),
+            np.array(["2175-10-06T17:46:40.000000000"], dtype="datetime64[ns]"),
+        ),
+    ],
+)
+def test_convert_casacore_time(times, expected_result):
+    from xradio.vis._vis_utils._ms._tables.read import convert_casacore_time
+
+    assert all(convert_casacore_time(times) == expected_result)
+
+
+@pytest.mark.parametrize(
+    "times, expected_result",
+    [
+        (
+            np.array([0, 50000]),
+            np.array(
+                ["1858-11-17T00:00:00.0", "1995-10-10T00:00:00.0"],
+                dtype="datetime64[ns]",
+            ),
+        ),
+        (
+            np.array([58000.123]),
+            np.array(["2017-09-04T02:57:07.199999744"], dtype="datetime64[ns]"),
+        ),
+        (
+            np.array([70000.34]),
+            np.array(["2050-07-13T08:09:36.0"], dtype="datetime64[ns]"),
+        ),
+    ],
+)
+def test_convert_mjd_time(times, expected_result, request):
+    from xradio.vis._vis_utils._ms._tables.read import convert_mjd_time
+
+    assert all(convert_mjd_time(times) == expected_result)
+
+
+
+def test_extract_table_attributes_main(ms_minimal_required):
+    from xradio.vis._vis_utils._ms._tables.read import extract_table_attributes
+
+    res = extract_table_attributes(ms_minimal_required.fname)
+    assert all(entry in res for entry in ["MS_VERSION", "column_descriptions", "info"])
+    assert all(sub in res["info"] for sub in ["type", "subType", "readme"])
+    assert len(res["column_descriptions"]) == 22
+    columns = ["TIME", "DATA_DESC_ID", "ANTENNA1", "ANTENNA2", "WEIGHT"]
+    assert all([col in res["column_descriptions"] for col in columns])
+
+    
+def test_extract_table_attributes_ant(ms_minimal_required):
+    from xradio.vis._vis_utils._ms._tables.read import extract_table_attributes
+
+    res = extract_table_attributes(str(Path(ms_minimal_required.fname) / "ANTENNA"))
+    assert len(res) == 2
+    assert "column_descriptions" in res
+    assert "info" in res
+    assert len(res["column_descriptions"]) == 8
+    cols = ["DISH_DIAMETER", "FLAG_ROW", "MOUNT", "NAME", "OFFSET", "POSITION"]
+    assert all([col in res["column_descriptions"] for col in cols])
+    assert all(sub in res["info"] for sub in ["type", "subType", "readme"])
+
+
+def test_add_units_measures(main_xds_min):
+    from xradio.vis._vis_utils._ms._tables.read import add_units_measures
+
+    col_descr = {"column_descriptions": {}}
+    xds_vars = {"uvw": main_xds_min.uvw, "time": main_xds_min.time}
+    res = add_units_measures(xds_vars, col_descr)
+    assert xds_vars["uvw"].attrs
+    assert xds_vars["time"].attrs
+
+
+def test_make_freq_attrs_uvw(spw_xds_min):
+    from xradio.vis._vis_utils._ms._tables.read import make_freq_attrs
+
+    res = make_freq_attrs(spw_xds_min, 0)
+    expected = {'measure': {'ref_frame': 'REST', 'type': 'frequency'}, 'units': 'Hz'}
+    assert res == expected
+
+
+def test_get_pad_nan_uvw(main_xds_min):
+    from xradio.vis._vis_utils._ms._tables.read import get_pad_nan
+    
+    res = get_pad_nan(main_xds_min.data_vars["uvw"])
+    assert np.isnan(res)
+
+
+def test_get_pad_nan_feed1(main_xds_min):
+    from xradio.vis._vis_utils._ms._tables.read import get_pad_nan
+    
+    res = get_pad_nan(main_xds_min.data_vars["feed1_id"])
+    assert res == -2147483648
+
+
+def test_redimension_ms_subtable_source(source_xds_min):
+    from xradio.vis._vis_utils._ms._tables.read import redimension_ms_subtable
+    import xarray as xr
+
+    res = redimension_ms_subtable(source_xds_min, "SOURCE")
+    assert isinstance(res, xr.Dataset)
+    src_coords = ["source_id", "time", "spectral_window_id", "pulsar_id"]
+    assert all([coord in res.coords for coord in src_coords])
+
+
+def test_is_ephem_subtable_ms(ms_minimal_required):
+    from xradio.vis._vis_utils._ms._tables.read import is_ephem_subtable
+
+    res = is_ephem_subtable(ms_minimal_required.fname)
+    assert res == False
+
+
+def test_add_ephemeris_vars(ms_minimal_required):
+    from xradio.vis._vis_utils._ms._tables.read import add_ephemeris_vars
+    import xarray as xr
+
+    # would need an ephem_xds fixture
+    ephem_xds = xr.Dataset(data_vars={"mjd": ("row", np.array([]))})
+    res = add_ephemeris_vars(Path(ms_minimal_required.fname) / "FIELD" / "EPHEM0_f0.tab",
+                             ephem_xds)
+    assert res
+    assert all([xvar in res.data_vars for xvar in ["ephemeris_row_id", "ephemeris_id", "time"]])
+
+
+def test_is_nested_ms_empty():
+    from xradio.vis._vis_utils._ms._tables.read import is_nested_ms
+
+    with pytest.raises(KeyError, match="other"):
+        res = is_nested_ms({})
+        assert res == False
+
+
+def test_is_nested_ms_ant(ms_minimal_required):
+    from xradio.vis._vis_utils._ms._tables.read import is_nested_ms
+    from xradio.vis._vis_utils._ms._tables.read import extract_table_attributes
+
+    ant_subt = str(Path(ms_minimal_required.fname) / "ANTENNA")
+    ctds_attrs = extract_table_attributes(ms_minimal_required.fname)
+    attrs = {"other": {"msv2": {"ctds_attrs": ctds_attrs}}}
+
+    res = is_nested_ms(attrs)
+    assert res == True
+
+
+def test_is_nested_ms_ms_min(ms_minimal_required):
+    from xradio.vis._vis_utils._ms._tables.read import is_nested_ms
+    from xradio.vis._vis_utils._ms._tables.read import extract_table_attributes
+    ctds_attrs = extract_table_attributes(ms_minimal_required.fname)
+    attrs = {"other": {"msv2": {"ctds_attrs": ctds_attrs}}}
+
+    res = is_nested_ms(attrs)
+    assert res == True
+
+
+def test_read_generic_table_ant(ms_minimal_required):
+    from xradio.vis._vis_utils._ms._tables.read import read_generic_table
+    import xarray as xr
+
+    res = read_generic_table(ms_minimal_required.fname, "ANTENNA")
+    assert res
+    assert type(res) == xr.Dataset
+    assert all([dim in res.dims for dim in ["row", "dim_1"]])
+
+
+def test_read_generic_table_state(ms_minimal_required):
+    from xradio.vis._vis_utils._ms._tables.read import read_generic_table
+    import xarray as xr
+
+    res = read_generic_table(ms_minimal_required.fname, "STATE")
+    assert res
+    assert type(res) == xr.Dataset
+    assert all([dim in res.dims for dim in ["row"]])
+    assert all([xvar in res.data_vars for xvar in ["cal", "load", "sig", "sub_scan", "obs_mode"]])
+
+
+def test_read_generic_table_ephem(ms_minimal_required):
+    from xradio.vis._vis_utils._ms._tables.read import read_generic_table
+    import xarray as xr
+
+    res = read_generic_table(ms_minimal_required.fname, "FIELD/EPHEM0_FIELDNAME.tab")
+    exp_attrs = {'other': {'msv2': {
+        'bad_cols': ['MJD'],
+        'ctds_attrs': {'column_descriptions': {'MJD': {'valueType': 'double', 'dataManagerType': 'StandardStMan',
+                         'dataManagerGroup': 'StandardStMan', 'option': 0, 'maxlen': 0,
+                         'comment': 'comment...',
+                         'keywords': {'QuantumUnits': ['s'],
+                                      'MEASINFO': {'type': 'epoch', 'Ref': 'bogus MJD'}}}
+                                               },
+                       'info': {'readme': '',  'subType': '', 'type': ''}}}}}
+    assert isinstance(res, xr.Dataset)
+    assert all([dim in res.dims for dim in ["ephemeris_row_id", "ephemeris_id"]])
+    assert "time" in res.data_vars
+    assert res.data_vars["time"].size == 1
+    assert res.attrs == exp_attrs
+
+
+def test_read_generic_cols_state(ms_minimal_required):
+    from xradio.vis._vis_utils._ms._tables.read import read_generic_cols
+    from xradio.vis._vis_utils._ms._tables.table_query import open_table_ro
+    import xarray as xr
+
+    subt_state = str(Path(ms_minimal_required.fname) / "STATE")
+    with open_table_ro(subt_state) as tb_tool:
+        ignore_cols = ["FLAG_ROW"]
+        res = read_generic_cols(ms_minimal_required.fname, tb_tool,
+                                timecols=["TIME"], ignore=ignore_cols)
+        assert res
+        assert isinstance(res, tuple)
+        assert res[0] == {}
+        assert all([col.lower() not in res[1] for col in ignore_cols])
+        assert all([var in res[1] for var in ["load", "obs_mode", "ref", "sig", "sub_scan"]])
+        assert all([isinstance(val, xr.DataArray) for val in res[1].values()])
+
+
+def test_read_generic_cols_spw(ms_minimal_required):
+    from xradio.vis._vis_utils._ms._tables.read import read_generic_cols
+    from xradio.vis._vis_utils._ms._tables.table_query import open_table_ro
+    import xarray as xr
+
+    subt_state = str(Path(ms_minimal_required.fname) / "SPECTRAL_WINDOW")
+    with open_table_ro(subt_state) as tb_tool:
+        ignore_cols = ["FLAG_ROW"]
+        res = read_generic_cols(ms_minimal_required.fname, tb_tool,
+                                timecols=["TIME"], ignore=ignore_cols)
+        assert res
+        assert isinstance(res, tuple)
+        assert res[0] == {}
+        assert all([col not in res[1] for col in ignore_cols])
+        expected_vars = ["chan_freq", "ref_frequency", "effective_bw", "resolution",
+                         "freq_group", "freq_group_name", "if_conv_chain", "name",
+                         "net_sideband", "num_chan", "total_bandwidth"]
+        assert all([var in res[1] for var in expected_vars])
+        assert all([isinstance(val, xr.DataArray) for val in res[1].values()])
+
+
+def test_read_flat_col_chunk_time(ms_minimal_required):
+    from xradio.vis._vis_utils._ms._tables.read import read_flat_col_chunk
+
+    res = read_flat_col_chunk(ms_minimal_required.fname, "TIME",
+                              (10,), [0, 1, 5], 0, 0)
+    assert isinstance(res, np.ndarray)
+    assert res.shape == (3,)
+    assert np.all(res >= 1e9)
+
+
+def test_read_flat_col_chunk_sigma(ms_minimal_required):
+    from xradio.vis._vis_utils._ms._tables.read import read_flat_col_chunk
+
+    npols = ms_minimal_required.descr["npols"]
+    res = read_flat_col_chunk(ms_minimal_required.fname, "SIGMA", (10, npols), [4, 5, 8, 9], 0, 0)
+    assert isinstance(res, np.ndarray)
+    assert res.shape == (4, npols)
+    assert np.all(res == 1)
+
+
+def test_read_flat_col_chunk_flag(ms_minimal_required):
+    from xradio.vis._vis_utils._ms._tables.read import read_flat_col_chunk
+
+    npols = ms_minimal_required.descr["npols"]
+    nchans = ms_minimal_required.descr["nchans"]
+    res = read_flat_col_chunk(ms_minimal_required.fname, "FLAG", (10, 32, npols), [0, 1, 2], 0, 0)
+    assert isinstance(res, np.ndarray)
+    assert res.shape == (3, nchans, npols)
+    assert np.all(res == False)

--- a/tests/unit/vis/_vis_utils/_ms/_tables/test_read.py
+++ b/tests/unit/vis/_vis_utils/_ms/_tables/test_read.py
@@ -3,6 +3,7 @@ import pytest
 import numpy as np
 from pathlib import Path
 
+
 @pytest.mark.parametrize(
     "tab_name, expected_result",
     [
@@ -25,14 +26,14 @@ def test_table_exists(tab_name, expected_result, request):
         (
             np.array([0, 1_900_000_000.36]),
             np.array(
-                ["1858-11-17T00:00:00.0", "1919-02-01T17:46:40.360"],
+                ["1858-11-17T00:00:00.0", "1919-02-01T17:46:40.359999895"],
                 dtype="datetime64[ns]",
             ),
         ),
         (np.array([10]), np.array([], dtype="datetime64[ns]")),
         (
             np.array([5_000_000_000.1234]),
-            np.array(["2017-04-27T08:53:20.123399680"], dtype="datetime64[ns]"),
+            np.array(["2017-04-27T08:53:20.123399734"], dtype="datetime64[ns]"),
         ),
         (
             np.array([10_000_000_000]),
@@ -58,7 +59,7 @@ def test_convert_casacore_time(times, expected_result):
         ),
         (
             np.array([58000.123]),
-            np.array(["2017-09-04T02:57:07.199999744"], dtype="datetime64[ns]"),
+            np.array(["2017-09-04T02:57:07.199999809"], dtype="datetime64[ns]"),
         ),
         (
             np.array([70000.34]),
@@ -72,7 +73,6 @@ def test_convert_mjd_time(times, expected_result, request):
     assert all(convert_mjd_time(times) == expected_result)
 
 
-
 def test_extract_table_attributes_main(ms_minimal_required):
     from xradio.vis._vis_utils._ms._tables.read import extract_table_attributes
 
@@ -83,7 +83,7 @@ def test_extract_table_attributes_main(ms_minimal_required):
     columns = ["TIME", "DATA_DESC_ID", "ANTENNA1", "ANTENNA2", "WEIGHT"]
     assert all([col in res["column_descriptions"] for col in columns])
 
-    
+
 def test_extract_table_attributes_ant(ms_minimal_required):
     from xradio.vis._vis_utils._ms._tables.read import extract_table_attributes
 
@@ -111,20 +111,20 @@ def test_make_freq_attrs_uvw(spw_xds_min):
     from xradio.vis._vis_utils._ms._tables.read import make_freq_attrs
 
     res = make_freq_attrs(spw_xds_min, 0)
-    expected = {'measure': {'ref_frame': 'REST', 'type': 'frequency'}, 'units': 'Hz'}
+    expected = {"measure": {"ref_frame": "REST", "type": "frequency"}, "units": "Hz"}
     assert res == expected
 
 
 def test_get_pad_nan_uvw(main_xds_min):
     from xradio.vis._vis_utils._ms._tables.read import get_pad_nan
-    
+
     res = get_pad_nan(main_xds_min.data_vars["uvw"])
     assert np.isnan(res)
 
 
 def test_get_pad_nan_feed1(main_xds_min):
     from xradio.vis._vis_utils._ms._tables.read import get_pad_nan
-    
+
     res = get_pad_nan(main_xds_min.data_vars["feed1_id"])
     assert res == -2147483648
 
@@ -152,10 +152,13 @@ def test_add_ephemeris_vars(ms_minimal_required):
 
     # would need an ephem_xds fixture
     ephem_xds = xr.Dataset(data_vars={"mjd": ("row", np.array([]))})
-    res = add_ephemeris_vars(Path(ms_minimal_required.fname) / "FIELD" / "EPHEM0_f0.tab",
-                             ephem_xds)
+    res = add_ephemeris_vars(
+        Path(ms_minimal_required.fname) / "FIELD" / "EPHEM0_f0.tab", ephem_xds
+    )
     assert res
-    assert all([xvar in res.data_vars for xvar in ["ephemeris_row_id", "ephemeris_id", "time"]])
+    assert all(
+        [xvar in res.data_vars for xvar in ["ephemeris_row_id", "ephemeris_id", "time"]]
+    )
 
 
 def test_is_nested_ms_empty():
@@ -181,6 +184,7 @@ def test_is_nested_ms_ant(ms_minimal_required):
 def test_is_nested_ms_ms_min(ms_minimal_required):
     from xradio.vis._vis_utils._ms._tables.read import is_nested_ms
     from xradio.vis._vis_utils._ms._tables.read import extract_table_attributes
+
     ctds_attrs = extract_table_attributes(ms_minimal_required.fname)
     attrs = {"other": {"msv2": {"ctds_attrs": ctds_attrs}}}
 
@@ -206,7 +210,12 @@ def test_read_generic_table_state(ms_minimal_required):
     assert res
     assert type(res) == xr.Dataset
     assert all([dim in res.dims for dim in ["row"]])
-    assert all([xvar in res.data_vars for xvar in ["cal", "load", "sig", "sub_scan", "obs_mode"]])
+    assert all(
+        [
+            xvar in res.data_vars
+            for xvar in ["cal", "load", "sig", "sub_scan", "obs_mode"]
+        ]
+    )
 
 
 def test_read_generic_table_ephem(ms_minimal_required):
@@ -214,15 +223,30 @@ def test_read_generic_table_ephem(ms_minimal_required):
     import xarray as xr
 
     res = read_generic_table(ms_minimal_required.fname, "FIELD/EPHEM0_FIELDNAME.tab")
-    exp_attrs = {'other': {'msv2': {
-        'bad_cols': ['MJD'],
-        'ctds_attrs': {'column_descriptions': {'MJD': {'valueType': 'double', 'dataManagerType': 'StandardStMan',
-                         'dataManagerGroup': 'StandardStMan', 'option': 0, 'maxlen': 0,
-                         'comment': 'comment...',
-                         'keywords': {'QuantumUnits': ['s'],
-                                      'MEASINFO': {'type': 'epoch', 'Ref': 'bogus MJD'}}}
-                                               },
-                       'info': {'readme': '',  'subType': '', 'type': ''}}}}}
+    exp_attrs = {
+        "other": {
+            "msv2": {
+                "bad_cols": ["MJD"],
+                "ctds_attrs": {
+                    "column_descriptions": {
+                        "MJD": {
+                            "valueType": "double",
+                            "dataManagerType": "StandardStMan",
+                            "dataManagerGroup": "StandardStMan",
+                            "option": 0,
+                            "maxlen": 0,
+                            "comment": "comment...",
+                            "keywords": {
+                                "QuantumUnits": ["s"],
+                                "MEASINFO": {"type": "epoch", "Ref": "bogus MJD"},
+                            },
+                        }
+                    },
+                    "info": {"readme": "", "subType": "", "type": ""},
+                },
+            }
+        }
+    }
     assert isinstance(res, xr.Dataset)
     assert all([dim in res.dims for dim in ["ephemeris_row_id", "ephemeris_id"]])
     assert "time" in res.data_vars
@@ -230,41 +254,55 @@ def test_read_generic_table_ephem(ms_minimal_required):
     assert res.attrs == exp_attrs
 
 
-def test_read_generic_cols_state(ms_minimal_required):
-    from xradio.vis._vis_utils._ms._tables.read import read_generic_cols
+def test_load_generic_cols_state(ms_minimal_required):
+    from xradio.vis._vis_utils._ms._tables.read import load_generic_cols
     from xradio.vis._vis_utils._ms._tables.table_query import open_table_ro
     import xarray as xr
 
     subt_state = str(Path(ms_minimal_required.fname) / "STATE")
     with open_table_ro(subt_state) as tb_tool:
         ignore_cols = ["FLAG_ROW"]
-        res = read_generic_cols(ms_minimal_required.fname, tb_tool,
-                                timecols=["TIME"], ignore=ignore_cols)
+        res = load_generic_cols(
+            ms_minimal_required.fname, tb_tool, timecols=["TIME"], ignore=ignore_cols
+        )
         assert res
         assert isinstance(res, tuple)
         assert res[0] == {}
         assert all([col.lower() not in res[1] for col in ignore_cols])
-        assert all([var in res[1] for var in ["load", "obs_mode", "ref", "sig", "sub_scan"]])
+        assert all(
+            [var in res[1] for var in ["load", "obs_mode", "ref", "sig", "sub_scan"]]
+        )
         assert all([isinstance(val, xr.DataArray) for val in res[1].values()])
 
 
-def test_read_generic_cols_spw(ms_minimal_required):
-    from xradio.vis._vis_utils._ms._tables.read import read_generic_cols
+def test_load_generic_cols_spw(ms_minimal_required):
+    from xradio.vis._vis_utils._ms._tables.read import load_generic_cols
     from xradio.vis._vis_utils._ms._tables.table_query import open_table_ro
     import xarray as xr
 
     subt_state = str(Path(ms_minimal_required.fname) / "SPECTRAL_WINDOW")
     with open_table_ro(subt_state) as tb_tool:
         ignore_cols = ["FLAG_ROW"]
-        res = read_generic_cols(ms_minimal_required.fname, tb_tool,
-                                timecols=["TIME"], ignore=ignore_cols)
+        res = load_generic_cols(
+            ms_minimal_required.fname, tb_tool, timecols=["TIME"], ignore=ignore_cols
+        )
         assert res
         assert isinstance(res, tuple)
         assert res[0] == {}
         assert all([col not in res[1] for col in ignore_cols])
-        expected_vars = ["chan_freq", "ref_frequency", "effective_bw", "resolution",
-                         "freq_group", "freq_group_name", "if_conv_chain", "name",
-                         "net_sideband", "num_chan", "total_bandwidth"]
+        expected_vars = [
+            "chan_freq",
+            "ref_frequency",
+            "effective_bw",
+            "resolution",
+            "freq_group",
+            "freq_group_name",
+            "if_conv_chain",
+            "name",
+            "net_sideband",
+            "num_chan",
+            "total_bandwidth",
+        ]
         assert all([var in res[1] for var in expected_vars])
         assert all([isinstance(val, xr.DataArray) for val in res[1].values()])
 
@@ -272,8 +310,7 @@ def test_read_generic_cols_spw(ms_minimal_required):
 def test_read_flat_col_chunk_time(ms_minimal_required):
     from xradio.vis._vis_utils._ms._tables.read import read_flat_col_chunk
 
-    res = read_flat_col_chunk(ms_minimal_required.fname, "TIME",
-                              (10,), [0, 1, 5], 0, 0)
+    res = read_flat_col_chunk(ms_minimal_required.fname, "TIME", (10,), [0, 1, 5], 0, 0)
     assert isinstance(res, np.ndarray)
     assert res.shape == (3,)
     assert np.all(res >= 1e9)
@@ -283,7 +320,9 @@ def test_read_flat_col_chunk_sigma(ms_minimal_required):
     from xradio.vis._vis_utils._ms._tables.read import read_flat_col_chunk
 
     npols = ms_minimal_required.descr["npols"]
-    res = read_flat_col_chunk(ms_minimal_required.fname, "SIGMA", (10, npols), [4, 5, 8, 9], 0, 0)
+    res = read_flat_col_chunk(
+        ms_minimal_required.fname, "SIGMA", (10, npols), [4, 5, 8, 9], 0, 0
+    )
     assert isinstance(res, np.ndarray)
     assert res.shape == (4, npols)
     assert np.all(res == 1)
@@ -294,7 +333,9 @@ def test_read_flat_col_chunk_flag(ms_minimal_required):
 
     npols = ms_minimal_required.descr["npols"]
     nchans = ms_minimal_required.descr["nchans"]
-    res = read_flat_col_chunk(ms_minimal_required.fname, "FLAG", (10, 32, npols), [0, 1, 2], 0, 0)
+    res = read_flat_col_chunk(
+        ms_minimal_required.fname, "FLAG", (10, 32, npols), [0, 1, 2], 0, 0
+    )
     assert isinstance(res, np.ndarray)
     assert res.shape == (3, nchans, npols)
     assert np.all(res == False)

--- a/tests/unit/vis/_vis_utils/_ms/_tables/test_read_main_table.py
+++ b/tests/unit/vis/_vis_utils/_ms/_tables/test_read_main_table.py
@@ -1,0 +1,81 @@
+import pytest
+
+def test_rename_vars():
+    from xradio.vis._vis_utils._ms._tables.read_main_table import rename_vars
+
+    
+def test_redim_id_data_vars():
+    from xradio.vis._vis_utils._ms._tables.read_main_table import redim_id_data_vars
+
+
+@pytest.mark.parametrize("where, expected_pids", [
+    ("where DATA_DESC_ID = 0 AND SCAN_NUMBER = 1 AND STATE_ID = 1", {'array_id': [], 'observation_id': [], 'processor_id': []}),
+    ("where DATA_DESC_ID = 0 AND SCAN_NUMBER = 1 AND STATE_ID = 0", {'array_id': [0], 'observation_id': [0], 'processor_id': [0]}),
+])
+def test_get_parittion_ids(ms_minimal_required, where, expected_pids):
+    from xradio.vis._vis_utils._ms._tables.read_main_table import get_partition_ids
+    from xradio.vis._vis_utils._ms._tables.table_query import open_table_ro
+
+    with open_table_ro(ms_minimal_required.fname) as mtable:
+        pids = get_partition_ids(mtable, where)
+        assert pids == expected_pids
+
+
+def test_read_expanded_main_table():
+    from xradio.vis._vis_utils._ms._tables.read_main_table import read_expanded_main_table
+
+    # tested one level up for now
+
+
+def test_read_main_table_chunks():
+    from xradio.vis._vis_utils._ms._tables.read_main_table import read_main_table_chunks
+
+    # tested one level up for now
+
+
+# TODO: missing:
+
+# get_utimes_tol
+
+# get_baselines
+
+# read_all_cols_bvars
+
+# concat_bvars_update_tvars
+
+# concat_tvars_to_mvars
+
+
+def test_read_flat_main_table_w_scan_subscan(ms_minimal_required):
+    from xradio.vis._vis_utils._ms._tables.read_main_table import read_flat_main_table
+    import xarray as  xr
+    
+    # with pytest.raises(IndexError, match=""):
+    res = read_flat_main_table(ms_minimal_required.fname, 0, (1, 0))
+    assert res
+    assert isinstance(res, tuple)
+    assert isinstance(res[0], xr.Dataset)
+    assert isinstance(res[1], dict)
+    assert isinstance(res[2], dict)
+
+
+def test_read_flat_main_table_no_scan(ms_empty_required):
+    from xradio.vis._vis_utils._ms._tables.read_main_table import read_flat_main_table
+    import xarray as xr
+    
+    res = read_flat_main_table(ms_empty_required.fname, 0, None)
+    assert isinstance(res, tuple)
+    assert isinstance(res[0], xr.Dataset)
+    assert isinstance(res[1], dict)
+    assert isinstance(res[2], dict)
+
+
+def test_read_flat_main_table_no_subscan(ms_empty_required):
+    from xradio.vis._vis_utils._ms._tables.read_main_table import read_flat_main_table
+    import xarray as xr
+    
+    res = read_flat_main_table(ms_empty_required.fname, 1, (1, None))
+    assert isinstance(res, tuple)
+    assert isinstance(res[0], xr.Dataset)
+    assert isinstance(res[1], dict)
+    assert isinstance(res[2], dict)

--- a/tests/unit/vis/_vis_utils/_ms/_tables/test_read_subtables.py
+++ b/tests/unit/vis/_vis_utils/_ms/_tables/test_read_subtables.py
@@ -1,0 +1,32 @@
+import pytest
+
+import pandas as pd
+
+def test_normalize_time_slice_invalid():
+    from xradio.vis._vis_utils._ms._tables.read_subtables import normalize_time_slice
+
+    with pytest.raises(TypeError, match="argument must be"):
+        res = normalize_time_slice(None, slice({}, {}))
+
+
+def test_normalize_time_slice_invalid_content():
+    from xradio.vis._vis_utils._ms._tables.read_subtables import normalize_time_slice
+
+    with pytest.raises(ValueError, match="Invalid time type"):
+        res = normalize_time_slice(None, slice(3.3, 0.1))
+
+
+def test_normalize_time_slice_pd_timestamp():
+    from xradio.vis._vis_utils._ms._tables.read_subtables import normalize_time_slice
+
+    tstamp = pd.Timestamp(1000)
+    with pytest.raises(AttributeError, match="has no attribute"):
+        res = normalize_time_slice(None, slice(tstamp, tstamp))
+
+
+def test_normalize_time_slice():
+    from xradio.vis._vis_utils._ms._tables.read_subtables import normalize_time_slice
+
+    with pytest.raises(RuntimeError, match="Error in TaQL"):
+        res = normalize_time_slice(None, slice(0, 33))
+        assert res == 33

--- a/tests/unit/vis/_vis_utils/_ms/_tables/test_write.py
+++ b/tests/unit/vis/_vis_utils/_ms/_tables/test_write.py
@@ -1,4 +1,5 @@
 import pytest
+from pathlib import Path
 
 import numpy as np
 
@@ -42,18 +43,18 @@ def test_type_converter(nptype, expected_result):
     assert type_converter(nptype) == expected_result
 
 
-def test_create_table_pol(pol_xds_min):
+def test_create_table_pol(pol_xds_min, tmp_path):
     from xradio.vis._vis_utils._ms._tables.write import create_table
 
-    outtab = "test_create_table_pol_out.tab"
+    outtab = str(Path(tmp_path, "test_create_table_pol_out.tab"))
     create_table(outfile=outtab, xds=pol_xds_min, max_rows=100, generic=True)
 
 
-def test_create_table_ant_with_col(ant_xds_min):
+def test_create_table_ant_with_col(ant_xds_min, tmp_path):
     """Writes sub-list of columns"""
     from xradio.vis._vis_utils._ms._tables.write import create_table
 
-    outtab = "test_create_table_ant_out.tab"
+    outtab = str(Path(tmp_path, "test_create_table_ant_out.tab"))
     create_table(
         outfile=outtab,
         xds=ant_xds_min,
@@ -63,11 +64,11 @@ def test_create_table_ant_with_col(ant_xds_min):
     )
 
 
-def test_create_table_with_infile(main_xds_min, ms_minimal_required):
+def test_create_table_with_infile(main_xds_min, ms_minimal_required, tmp_path):
     """Uses the 'infile' param to provide a source of subtables to be copied over"""
     from xradio.vis._vis_utils._ms._tables.write import create_table
 
-    outtab = "test_create_table_main_with_infile.tab"
+    outtab = str(Path(tmp_path, "test_create_table_main_with_infile.tab"))
     create_table(
         outfile=outtab,
         xds=main_xds_min,
@@ -78,22 +79,27 @@ def test_create_table_with_infile(main_xds_min, ms_minimal_required):
     )
 
 
-def test_write_generic_table_ant(ant_xds_min):
+def test_write_generic_table_ant(ant_xds_min, tmp_path):
     from xradio.vis._vis_utils._ms._tables.write import write_generic_table
 
-    dirname = "test_write_generic_table.ant"
+    dirname = Path(tmp_path, "test_write_generic_table.ant")
     write_generic_table(ant_xds_min, outfile=dirname, subtable="")
 
 
-def test_write_generic_table_ant_named(ant_xds_min, ms_minimal_for_writes):
+def test_write_generic_table_ant_named(
+    ant_xds_min,
+    ms_minimal_for_writes,
+):
     """giving subtable name which will require the presence of a parent main table"""
     from xradio.vis._vis_utils._ms._tables.write import write_generic_table
 
-    write_generic_table(ant_xds_min, outfile=ms_minimal_for_writes.fname, subtable="antenna")
+    write_generic_table(
+        ant_xds_min, outfile=ms_minimal_for_writes.fname, subtable="antenna"
+    )
 
 
-def test_write_generic_table_pol(pol_xds_min):
+def test_write_generic_table_pol(pol_xds_min, tmp_path):
     from xradio.vis._vis_utils._ms._tables.write import write_generic_table
 
-    dirname = "test_write_generic_table.pol"
+    dirname = Path(tmp_path, "test_write_generic_table.pol")
     write_generic_table(pol_xds_min, outfile=dirname, subtable="")

--- a/tests/unit/vis/_vis_utils/_ms/_tables/test_write.py
+++ b/tests/unit/vis/_vis_utils/_ms/_tables/test_write.py
@@ -1,0 +1,99 @@
+import pytest
+
+import numpy as np
+
+
+@pytest.mark.parametrize(
+    "datetimes, expected_result",
+    [
+        (np.array([0]), np.array([3.5067168e09])),
+        (
+            np.array([-1, 10, 1_000_000_000_000, 1_000_000_000_000_000]),
+            np.array([3.5067168e09, 3.5067168e09, 3.5067178e09, 3.5077168e09]),
+        ),
+    ],
+)
+def test_revert_time(datetimes, expected_result):
+    from xradio.vis._vis_utils._ms._tables.write import revert_time
+
+    assert all(revert_time(datetimes) == expected_result)
+
+
+@pytest.mark.parametrize(
+    "nptype, expected_result",
+    [
+        ("int64", "int"),
+        ("int32", "int"),
+        ("bool", "bool"),
+        ("float32", "float"),
+        ("float64", "double"),
+        ("datetime64[ns]", "double"),
+        ("complex64", "complex"),
+        ("complex128", "dcomplex"),
+        ("<U34", "string"),
+        (None, "bad"),
+        ("", "bad"),
+        ("foo", "bad"),
+    ],
+)
+def test_type_converter(nptype, expected_result):
+    from xradio.vis._vis_utils._ms._tables.write import type_converter
+
+    assert type_converter(nptype) == expected_result
+
+
+def test_create_table_pol(pol_xds_min):
+    from xradio.vis._vis_utils._ms._tables.write import create_table
+
+    outtab = "test_create_table_pol_out.tab"
+    create_table(outfile=outtab, xds=pol_xds_min, max_rows=100, generic=True)
+
+
+def test_create_table_ant_with_col(ant_xds_min):
+    """Writes sub-list of columns"""
+    from xradio.vis._vis_utils._ms._tables.write import create_table
+
+    outtab = "test_create_table_ant_out.tab"
+    create_table(
+        outfile=outtab,
+        xds=ant_xds_min,
+        max_rows=100,
+        cols={"NAME": "name", "POSITION": "position", "DISH_DIAMETER": "dish_diameter"},
+        generic=True,
+    )
+
+
+def test_create_table_with_infile(main_xds_min, ms_minimal_required):
+    """Uses the 'infile' param to provide a source of subtables to be copied over"""
+    from xradio.vis._vis_utils._ms._tables.write import create_table
+
+    outtab = "test_create_table_main_with_infile.tab"
+    create_table(
+        outfile=outtab,
+        xds=main_xds_min,
+        infile=ms_minimal_required.fname,
+        max_rows=10,
+        cols={"TIME": "time", "SCAN_NUMBER": "scan_number"},
+        generic=False,
+    )
+
+
+def test_write_generic_table_ant(ant_xds_min):
+    from xradio.vis._vis_utils._ms._tables.write import write_generic_table
+
+    dirname = "test_write_generic_table.ant"
+    write_generic_table(ant_xds_min, outfile=dirname, subtable="")
+
+
+def test_write_generic_table_ant_named(ant_xds_min, ms_minimal_for_writes):
+    """giving subtable name which will require the presence of a parent main table"""
+    from xradio.vis._vis_utils._ms._tables.write import write_generic_table
+
+    write_generic_table(ant_xds_min, outfile=ms_minimal_for_writes.fname, subtable="antenna")
+
+
+def test_write_generic_table_pol(pol_xds_min):
+    from xradio.vis._vis_utils._ms._tables.write import write_generic_table
+
+    dirname = "test_write_generic_table.pol"
+    write_generic_table(pol_xds_min, outfile=dirname, subtable="")

--- a/tests/unit/vis/_vis_utils/_ms/_tables/test_write_exp_api.py
+++ b/tests/unit/vis/_vis_utils/_ms/_tables/test_write_exp_api.py
@@ -1,0 +1,62 @@
+import pytest
+
+@pytest.mark.parametrize("cols, expected_output", [
+    (['observation_id', 'vis', 'flag'],
+     {"OBSERVATION_ID": "observation_id", "DATA": "vis", "FLAG": "flag"}),
+    (["antenna1_id", "feed1_id"],
+     {"ANTENNA1": "antenna1_id", "FEED1": "feed1_id"}),
+])
+def test_cols_from_xds_to_ms(cols, expected_output):
+    from xradio.vis._vis_utils._ms._tables.write_exp_api import cols_from_xds_to_ms
+
+    assert cols_from_xds_to_ms(cols) == expected_output
+
+
+def test_write_ms_with_cds():
+    from xradio.vis._vis_utils._ms._tables.write_exp_api import write_ms
+    from xradio.vis._vis_utils._utils.cds import CASAVisSet
+
+    with pytest.raises(IndexError, match="out of range"):
+        write_ms(CASAVisSet({}, {}, "empty"), "test_out_vis.ms")
+
+
+def test_write_ms_empty():
+    from xradio.vis._vis_utils._ms._tables.write_exp_api import write_ms
+    from xradio.vis._vis_utils._utils.xds_helper import vis_xds_packager_mxds
+
+    mxds = vis_xds_packager_mxds({}, {}, add_global_coords=True)
+    with pytest.raises(IndexError, match="out of range"):
+        write_ms(mxds, outfile="test_out_write_ms_empty.ms")
+
+
+def test_write_ms_serial_empty():
+    from xradio.vis._vis_utils._ms._tables.write_exp_api import write_ms_serial
+    from xradio.vis._vis_utils._utils.xds_helper import vis_xds_packager_mxds
+
+    mxds = vis_xds_packager_mxds({}, {}, add_global_coords=True)
+    with pytest.raises(IndexError, match="out of range"):
+        write_ms_serial(mxds, outfile="test_out_write_ms_empty.ms")
+
+
+def test_write_ms_cds_min(cds_minimal_required):
+    from xradio.vis._vis_utils._ms._tables.write_exp_api import write_ms
+    from xradio.vis._vis_utils._utils.xds_helper import vis_xds_packager_mxds
+
+    mxds_min = vis_xds_packager_mxds(
+        cds_minimal_required.partitions,
+        cds_minimal_required.metainfo,
+        add_global_coords=False,
+    )
+    write_ms(mxds_min, "test_write_cds_min_blah.ms", subtables=True, modcols={"FLAG": "flag"})
+
+
+def test_write_ms_serial_cds_min(cds_minimal_required):
+    from xradio.vis._vis_utils._ms._tables.write_exp_api import write_ms_serial
+    from xradio.vis._vis_utils._utils.xds_helper import vis_xds_packager_mxds
+
+    mxds_min = vis_xds_packager_mxds(
+        cds_minimal_required.partitions,
+        cds_minimal_required.metainfo,
+        add_global_coords=False,
+    )
+    write_ms_serial(mxds_min, "test_write_cds_min_blah.ms", subtables=True, verbose=True)

--- a/tests/unit/vis/_vis_utils/_ms/_tables/test_write_exp_api.py
+++ b/tests/unit/vis/_vis_utils/_ms/_tables/test_write_exp_api.py
@@ -1,11 +1,17 @@
 import pytest
+from pathlib import Path
 
-@pytest.mark.parametrize("cols, expected_output", [
-    (['observation_id', 'vis', 'flag'],
-     {"OBSERVATION_ID": "observation_id", "DATA": "vis", "FLAG": "flag"}),
-    (["antenna1_id", "feed1_id"],
-     {"ANTENNA1": "antenna1_id", "FEED1": "feed1_id"}),
-])
+
+@pytest.mark.parametrize(
+    "cols, expected_output",
+    [
+        (
+            ["observation_id", "vis", "flag"],
+            {"OBSERVATION_ID": "observation_id", "DATA": "vis", "FLAG": "flag"},
+        ),
+        (["antenna1_id", "feed1_id"], {"ANTENNA1": "antenna1_id", "FEED1": "feed1_id"}),
+    ],
+)
 def test_cols_from_xds_to_ms(cols, expected_output):
     from xradio.vis._vis_utils._ms._tables.write_exp_api import cols_from_xds_to_ms
 
@@ -38,7 +44,7 @@ def test_write_ms_serial_empty():
         write_ms_serial(mxds, outfile="test_out_write_ms_empty.ms")
 
 
-def test_write_ms_cds_min(cds_minimal_required):
+def test_write_ms_cds_min(cds_minimal_required, tmp_path):
     from xradio.vis._vis_utils._ms._tables.write_exp_api import write_ms
     from xradio.vis._vis_utils._utils.xds_helper import vis_xds_packager_mxds
 
@@ -47,10 +53,11 @@ def test_write_ms_cds_min(cds_minimal_required):
         cds_minimal_required.metainfo,
         add_global_coords=False,
     )
-    write_ms(mxds_min, "test_write_cds_min_blah.ms", subtables=True, modcols={"FLAG": "flag"})
+    outpath = str(Path(tmp_path, "test_write_cds_min_blah.ms"))
+    write_ms(mxds_min, outpath, subtables=True, modcols={"FLAG": "flag"})
 
 
-def test_write_ms_serial_cds_min(cds_minimal_required):
+def test_write_ms_serial_cds_min(cds_minimal_required, tmp_path):
     from xradio.vis._vis_utils._ms._tables.write_exp_api import write_ms_serial
     from xradio.vis._vis_utils._utils.xds_helper import vis_xds_packager_mxds
 
@@ -59,4 +66,5 @@ def test_write_ms_serial_cds_min(cds_minimal_required):
         cds_minimal_required.metainfo,
         add_global_coords=False,
     )
-    write_ms_serial(mxds_min, "test_write_cds_min_blah.ms", subtables=True, verbose=True)
+    outpath = str(Path(tmp_path, "test_write_cds_min_blah.ms"))
+    write_ms_serial(mxds_min, outpath, subtables=True, verbose=True)

--- a/tests/unit/vis/_vis_utils/_ms/test_chunks.py
+++ b/tests/unit/vis/_vis_utils/_ms/test_chunks.py
@@ -1,0 +1,9 @@
+import pytest
+
+def test_load_main_chunk_raises():
+    from xradio.vis._vis_utils._ms.chunks import load_main_chunk
+    name = "any"
+    with pytest.raises(ValueError, match="unknown keys"):
+        res = load_main_chunk(name, {"unk": range(0,3),
+                                     "baseline": range(0, 7),
+                                     "time": range(0, 100)})

--- a/tests/unit/vis/_vis_utils/_ms/test_conversion.py
+++ b/tests/unit/vis/_vis_utils/_ms/test_conversion.py
@@ -1,0 +1,254 @@
+from collections import namedtuple
+from contextlib import nullcontext as no_raises
+import numpy as np
+import pytest
+import xarray as xr
+
+import xradio.vis._vis_utils._ms.conversion as conv
+
+
+minxds = namedtuple("minxds", "data_vars coords sizes")
+xds_main = minxds(
+    {"VISIBILITY": np.empty((1), dtype=np.complex64)},
+    {"baseline_id"},
+    {
+        "time": 220,
+        "baseline_id": 55,
+        "frequency": 3890,
+        "polarization": 2,
+    },
+)
+xds_main_sd = minxds(
+    {"SPECTRUM": np.empty((1), dtype=np.complex64)},
+    {"antenna_id"},
+    {
+        "time": 1200,
+        "antenna_id": 11,
+        "frequency": 1800,
+        "polarization": 2,
+    },
+)
+xds_pointing = minxds(
+    {"BEAM_POINTING": np.empty((1), dtype=np.complex64)},
+    {"antenna_id"},
+    {
+        "time": 10220,
+        "antenna_id": 55,
+        "direction": 2,
+    },
+)
+xds_pointing_small = minxds(
+    {"BEAM_POINTING": np.empty((1), dtype=np.complex64)},
+    {"antenna_id"},
+    {
+        "time": 102,
+        "antenna_id": 12,
+        "direction": 2,
+    },
+)
+
+
+@pytest.mark.parametrize(
+    "input_chunksize, xds_type, xds, expected_chunksize, expected_error",
+    [
+        ({}, "main", None, {}, no_raises()),
+        ({}, "pointing", None, {}, no_raises()),
+        (
+            {"time": 10, "baseline_id": 5, "frequency": 100, "polarization": 2},
+            "main",
+            xds_main,
+            {"time": 10, "baseline_id": 5, "frequency": 100, "polarization": 2},
+            no_raises(),
+        ),
+        (
+            {"time": 10, "foo": 3},
+            "main",
+            xds_main,
+            {},
+            pytest.raises(ValueError, match="foo"),
+        ),
+        (
+            0.02,
+            "main",
+            xds_main,
+            {"time": 70, "baseline_id": 16, "frequency": 1198, "polarization": 2},
+            no_raises(),
+        ),
+        (
+            0.01,
+            "main",
+            xds_main_sd,
+            {"time": 408, "antenna_id": 3, "frequency": 548, "polarization": 2},
+            no_raises(),
+        ),
+        (
+            0.0002,
+            "pointing",
+            xds_pointing,
+            {"time": 1677, "antenna_id": 8, "direction": 2},
+            no_raises(),
+        ),
+    ],
+)
+def test_parse_chunksize(
+    input_chunksize, xds_type, xds, expected_chunksize, expected_error
+):
+    # parse_chunksize checks the input chunksize (if dict), or auto-calculates the
+    # sizes (if given as numeric memory value). The calculations are better tested for the
+    # lower level functions
+    with expected_error:
+        assert (
+            conv.parse_chunksize(input_chunksize, xds_type, xds) == expected_chunksize
+        )
+
+
+@pytest.mark.parametrize(
+    "chunksize, xds_type, expectation",
+    [
+        ({}, "main", no_raises()),
+        ({}, "pointing", no_raises()),
+        (
+            {"baseline_id": 1, "frequency": 2, "polarization": 3, "time": 4},
+            "main",
+            no_raises(),
+        ),
+        (
+            {"baseline_id": 1, "frequency": 2, "polarization": 3, "time": 4},
+            "pointing",
+            pytest.raises(ValueError, match="baseline_id"),
+        ),
+        ({"foo": "a"}, "main", pytest.raises(ValueError, match="foo")),
+        ({"foo": 1}, "pointing", pytest.raises(ValueError, match="foo")),
+    ],
+)
+def test_check_chunksize(chunksize, xds_type, expectation):
+    with expectation:
+        conv.check_chunksize(chunksize, xds_type)
+
+
+@pytest.mark.parametrize(
+    "pseudo_xds, xds_type, expected_chunksize, expected_error",
+    [
+        (
+            xds_main,
+            "main",
+            {"baseline_id": 28, "frequency": 2048, "polarization": 2, "time": 117},
+            no_raises(),
+        ),
+        (
+            xds_main,
+            "bar_wrong",
+            {"baseline_id": 28, "frequency": 2048, "polarization": 2, "time": 117},
+            pytest.raises(RuntimeError),
+        ),
+    ],
+)
+def test_mem_chunksize_to_dict(
+    pseudo_xds, xds_type, expected_chunksize, expected_error
+):
+    # mem_chunksize_to_dict relies on mem_chunksize_to_dict_main_*,
+    # mem_chunksize_to_dict_pointing*, etc. which are better tested below
+    with expected_error:
+        assert (
+            conv.mem_chunksize_to_dict(0.1, xds_type, pseudo_xds) == expected_chunksize
+        )
+
+
+@pytest.mark.parametrize(
+    "mem_size, pseudo_xds, expected_chunksize, expected_error",
+    [
+        (
+            1e-9,   # not enough even for one data point / all pols
+            xds_main,
+            {"baseline_id": 28, "frequency": 2048, "polarization": 2, "time": 117},
+            pytest.raises(RuntimeError, match="memory bound"),
+        ),
+        (
+            0.9,   # enough to hold all in mem
+            xds_main,
+            {"time": 220, "baseline_id": 55, "frequency": 3890, "polarization": 2},
+            no_raises(),
+        ),
+        (
+            0.01,
+            xds_main_sd,
+            {"antenna_id": 3, "frequency": 548, "polarization": 2, "time": 408},
+            no_raises(),
+        ),
+    ],
+)
+def test_mem_chunksize_to_dict_main(
+    mem_size, pseudo_xds, expected_chunksize, expected_error
+):
+    with expected_error:
+        assert conv.mem_chunksize_to_dict_main(mem_size, pseudo_xds) == expected_chunksize
+
+
+@pytest.mark.parametrize(
+    "mem_size, dim_sizes, expected_chunksize",
+    [
+        (
+            0.001,
+            {"time": 200, "baseline_id": 21, "frequency": 1000, "polarization": 3},
+            {"time": 50, "baseline_id": 4, "frequency": 223, "polarization": 3},
+        ),
+        (
+            0.02,
+            {"time": 200, "baseline_id": 21, "frequency": 1000, "polarization": 3},
+            {"time": 124, "baseline_id": 12, "frequency": 601, "polarization": 3},
+        ),
+        (
+            0.03,
+            {"time": 200, "baseline_id": 21, "frequency": 1000, "polarization": 3},
+            {"time": 140, "baseline_id": 14, "frequency": 684, "polarization": 3},
+        ),
+        (
+            0.05,
+            {"time": 200, "baseline_id": 21, "frequency": 1000, "polarization": 4},
+            {"time": 151, "baseline_id": 15, "frequency": 740, "polarization": 4},
+        ),
+    ],
+)
+def test_mem_chunksize_to_dict_main_balanced(mem_size, dim_sizes, expected_chunksize):
+    res = conv.mem_chunksize_to_dict_main_balanced(
+        mem_size, dim_sizes, "baseline_id", 8
+    )
+    assert res == pytest.approx(expected_chunksize)
+
+
+@pytest.mark.parametrize(
+    "mem_size, dim_sizes, expected_chunksize",
+    [
+        (
+            0.1,
+            xds_pointing,
+            {"time": 10220, "antenna_id": 55, "direction": 2},
+        ),
+        (
+            0.5,
+            xds_pointing_small,
+            xds_pointing_small.sizes,
+        ),
+        (0.5, minxds({}, {}, {}), {}),
+    ],
+)
+def test_mem_chunksize_to_dict_pointing(mem_size, dim_sizes, expected_chunksize):
+    res = conv.mem_chunksize_to_dict_pointing(mem_size, dim_sizes)
+    assert res == pytest.approx(expected_chunksize)
+
+
+def test_itemsize_vis_spec():
+    assert conv.itemsize_vis_spec(xds_main) == 8
+
+
+def itemsize_pointing_spec():
+    assert conv.itemsize_vis_spec(xds_pointing) == 8
+
+
+def test_calc_used_gb():
+    res = conv.calc_used_gb(
+        {"time": 200, "baseline_id": 21, "frequency": 1000, "polarization": 3},
+        "baseline_id",
+        8,
+    )
+    assert res == pytest.approx(0.0938773)

--- a/tests/unit/vis/_vis_utils/_ms/test_descr.py
+++ b/tests/unit/vis/_vis_utils/_ms/test_descr.py
@@ -1,0 +1,30 @@
+from contextlib import nullcontext as does_not_raise
+import pandas as pd
+import pytest
+
+@pytest.mark.parametrize("name, mode, expected_raises", [
+    ("inexistent_not_there.not_ms", "summary",
+     pytest.raises(ValueError, match="invalid input")),
+    ("test_ms_minimal_required.ms", "bogus",
+     pytest.raises(ValueError, match="invalid mode")),
+    ("test_ms_minimal_required.ms", "flat", does_not_raise()),
+    ("test_ms_minimal_required.ms",  "expanded",
+     pytest.raises(ValueError, match="update sequence element")),
+
+])
+def test_describe_ms_raises(name, mode, expected_raises):
+    from xradio.vis._vis_utils._ms.descr import describe_ms
+    with expected_raises:
+        describe_ms(name, mode=mode)
+
+
+@pytest.mark.parametrize("mode, expected_res", [
+    ("summary", (pd.DataFrame, 4)),
+    ("flat", (dict, 4)),
+])
+def test_describe_ms(ms_minimal_required, mode, expected_res):
+    from xradio.vis._vis_utils._ms.descr import describe_ms
+
+    res = describe_ms(ms_minimal_required.fname, mode)
+    assert type(res) == expected_res[0]
+    assert len(res) == expected_res[1]

--- a/tests/unit/vis/_vis_utils/_ms/test_partition_queries.py
+++ b/tests/unit/vis/_vis_utils/_ms/test_partition_queries.py
@@ -123,8 +123,8 @@ def test_filter_intents_per_ddi_wvr(mixed_intents_wvr, expected_results):
         8: "ALMA_R_B03#BB_4#SW-01#CH_AVG",
     }
 
-    with pytest.raises(KeyError, match="0"):
-        res = filter_intents_per_ddi([0], "WVR", mixed_intents_wvr, {})
+    res = filter_intents_per_ddi([0], "WVR", mixed_intents_wvr, {})
+    assert res == [mixed_intents_wvr]
 
     res = filter_intents_per_ddi([0], "WVR", mixed_intents_wvr, spw_name_by_ddi)
     assert res == expected_results
@@ -189,12 +189,15 @@ def test_make_partition_ids_by_ddi_intent_vlass(ms_vlass_subset_evla_36473386):
         ms_vlass_subset_evla_36473386.fname, xr.Dataset()
     )
 
-    nddis = 2
+    nddis = 1
     exp = (
         np.arange(nddis),
-        nddis * [None],
-        np.arange(4, 223),
-        ["OBSERVE_TARGET#UNSPECIFIED", "OBSERVE_TARGET#UNSPECIFIED"],
+        2 * nddis * [None],
+        np.stack((np.arange(22, 38), np.arange(38, 54)), axis=0),
+        [
+            "OBSERVE_TARGET#ON_SOURCE",
+            "OBSERVE_TARGET#ON_SOURCE,CALIBRATE_WVR#ON_SOURCE",
+        ],
     )
     assert res
     assert np.allclose(res[0], exp[0])

--- a/tests/unit/vis/_vis_utils/_ms/test_partition_queries.py
+++ b/tests/unit/vis/_vis_utils/_ms/test_partition_queries.py
@@ -1,0 +1,162 @@
+import numpy as np
+import pytest
+import shutil
+
+import xarray as xr
+
+
+# Tests for _vis_utils/_ms/partition_queries. Move to its own file
+def test_make_partition_ids_by_ddi_scan(ms_empty_required):
+    from xradio.vis._vis_utils._ms.partition_queries import make_partition_ids_by_ddi_scan
+
+    res = make_partition_ids_by_ddi_scan(ms_empty_required.fname, do_subscans=False)
+
+    exp = (np.empty(0, dtype=np.int32), np.empty(0, dtype=np.int32), [])
+    assert res
+    assert np.allclose(res[1], exp[1])
+    assert res[2] == exp[2]
+
+
+def test_make_partition_ids_by_ddi_scan_ms_min(ms_minimal_required):
+    from xradio.vis._vis_utils._ms.partition_queries import make_partition_ids_by_ddi_scan
+
+    res = make_partition_ids_by_ddi_scan(ms_minimal_required.fname, do_subscans=False)
+
+    nddis = ms_minimal_required.descr["nddis"]
+    exp = (np.arange(nddis, dtype=np.int32), np.ones(nddis, dtype=np.int32), nddis*[None])
+    assert res
+    assert np.allclose(res[0], exp[0])
+    assert np.allclose(res[1], exp[1])
+    assert res[2] == exp[2]
+
+
+def test_make_partition_ids_by_ddi_scan_subs(ms_empty_required):
+    from xradio.vis._vis_utils._ms.partition_queries import make_partition_ids_by_ddi_scan
+
+    res = make_partition_ids_by_ddi_scan(ms_empty_required.fname, do_subscans=True)
+
+    exp = ([], np.array([], dtype=np.int32), np.array([], dtype=np.int32))
+    assert res
+    assert res[0] == exp[0]
+    assert np.allclose(res[1], exp[1])
+    assert np.allclose(res[2], exp[2])
+
+
+def test_partition_when_empty_state(ms_empty_required):
+    from xradio.vis._vis_utils._ms.partition_queries import partition_when_empty_state
+
+    res = partition_when_empty_state(ms_empty_required.fname)
+
+    exp = (np.array([], dtype=np.int32), [], [])
+    assert res
+    assert np.allclose(res[0], exp[0])
+    assert res[1] == exp[1]
+    assert res[2] == exp[2]
+
+
+def test_find_distinct_obs_mode(ms_minimal_required):
+    from xradio.vis._vis_utils._ms.partition_queries import find_distinct_obs_mode
+
+    with pytest.raises(RuntimeError, match="Error in TaQL command"):
+        res = find_distinct_obs_mode(ms_minimal_required.fname, "name::STATE")
+        assert res
+
+
+@pytest.mark.parametrize("mixed_intents_no_wvr, expected_results", [
+    ("OBSERVE_TARGET#ON_SOURCE,POSITION_SWITCH", ["OBSERVE_TARGET#ON_SOURCE,POSITION_SWITCH"]),
+    ("OBSERVE_TARGET#ON_SOURCE", ["OBSERVE_TARGET#ON_SOURCE"]),
+])
+def test_filter_intents_per_ddi(mixed_intents_no_wvr, expected_results):
+    from xradio.vis._vis_utils._ms.partition_queries import filter_intents_per_ddi
+
+    spw_name_by_ddi = {0: "WVR#NOMINAL",
+                       1: "ALMA_R_B03#BB_1#SW-01#FULL_RES",
+                       }
+
+    res = filter_intents_per_ddi([0], "WVR", mixed_intents_no_wvr,
+                                 spw_name_by_ddi)
+    assert res == expected_results
+
+
+@pytest.mark.parametrize("mixed_intents_wvr, expected_results", [
+    ("CALIBRATE#BANDPASS,CALIBRATE#WVR", ["CALIBRATE#WVR"]),
+    ("CALIBRATE_ATMOSPHERE#OFF_SOURCE,CALIBRATE_WVR#OFF_SOURCE",
+     ["CALIBRATE_WVR#OFF_SOURCE"]),
+])
+def test_filter_intents_per_ddi_wvr(mixed_intents_wvr, expected_results):
+    from xradio.vis._vis_utils._ms.partition_queries import filter_intents_per_ddi
+
+    spw_name_by_ddi = {0: "WVR#NOMINAL",
+                       1: "ALMA_R_B03#BB_1#SW-01#FULL_RES",
+                       2: "ALMA_R_B03#BB_1#SW-01#CH_AVG",
+                       3: "ALMA_R_B03#BB_2#SW-01#FULL_RES",
+                       4: "ALMA_R_B03#BB_2#SW-01#CH_AVG",
+                       5: "ALMA_R_B03#BB_3#SW-01#FULL_RES",
+                       6: "ALMA_R_B03#BB_3#SW-01#CH_AVG",
+                       7: "ALMA_R_B03#BB_4#SW-01#FULL_RES",
+                       8: "ALMA_R_B03#BB_4#SW-01#CH_AVG",
+                       }
+    
+    with pytest.raises(KeyError, match="0"):
+        res = filter_intents_per_ddi([0], "WVR", mixed_intents_wvr,
+                                     {})
+
+    res = filter_intents_per_ddi([0], "WVR", mixed_intents_wvr, spw_name_by_ddi)
+    assert res == expected_results
+
+
+def test_make_ddi_state_intent_lists():
+    from xradio.vis._vis_utils._ms.partition_queries import make_ddi_state_intent_lists
+
+    res = make_ddi_state_intent_lists(None, None, np.empty(0), {})
+
+    exp = ([], [], [])
+    assert res
+    assert res == exp
+
+
+def test_make_partition_ids_by_ddi_intent_empty(ms_empty_required):
+    from xradio.vis._vis_utils._ms.partition_queries import make_partition_ids_by_ddi_intent
+
+    res = make_partition_ids_by_ddi_intent(ms_empty_required.fname, xr.Dataset())
+
+    exp = (np.array([], dtype=np.int32), [], [], [])
+    assert res
+    assert np.allclose(res[0], exp[0])
+    assert res[1] == exp[1]
+    assert res[2] == exp[2]
+    assert res[3] == exp[3]
+
+
+def test_make_partition_ids_by_ddi_intent_min(ms_minimal_required):
+    from xradio.vis._vis_utils._ms.partition_queries import make_partition_ids_by_ddi_intent
+
+    res = make_partition_ids_by_ddi_intent(ms_minimal_required.fname, xr.Dataset())
+    
+    nddis = ms_minimal_required.descr["nddis"]
+    exp = (np.arange(nddis, dtype=np.int32), nddis*[None], nddis*[np.array([0, 1])],
+           nddis*['scan_intent#subscan_intent'])
+
+    assert res
+    assert np.allclose(res[0], exp[0])
+    assert res[1] == exp[1]
+    assert len(res[2]) == nddis
+    # assert not (res[2][0] - exp[2][0]).any()
+    assert np.allclose(res[2][0], exp[2][0])
+    assert res[3] == exp[3]
+
+
+@pytest.mark.uses_gdown
+def test_make_partition_ids_by_ddi_intent_vlass(ms_vlass_subset_evla_36473386):
+    from xradio.vis._vis_utils._ms.partition_queries import make_partition_ids_by_ddi_intent
+
+    res = make_partition_ids_by_ddi_intent(ms_vlass_subset_evla_36473386.fname, xr.Dataset())
+
+    nddis = 2
+    exp = (np.arange(nddis), nddis*[None], np.arange(4, 223),
+           ['OBSERVE_TARGET#UNSPECIFIED', 'OBSERVE_TARGET#UNSPECIFIED'])
+    assert res
+    assert np.allclose(res[0], exp[0])
+    assert res[1] == exp[1]
+    assert np.allclose(res[2], exp[2])
+    assert res[3] == exp[3]

--- a/tests/unit/vis/_vis_utils/_ms/test_partition_queries.py
+++ b/tests/unit/vis/_vis_utils/_ms/test_partition_queries.py
@@ -7,7 +7,9 @@ import xarray as xr
 
 # Tests for _vis_utils/_ms/partition_queries. Move to its own file
 def test_make_partition_ids_by_ddi_scan(ms_empty_required):
-    from xradio.vis._vis_utils._ms.partition_queries import make_partition_ids_by_ddi_scan
+    from xradio.vis._vis_utils._ms.partition_queries import (
+        make_partition_ids_by_ddi_scan,
+    )
 
     res = make_partition_ids_by_ddi_scan(ms_empty_required.fname, do_subscans=False)
 
@@ -18,12 +20,18 @@ def test_make_partition_ids_by_ddi_scan(ms_empty_required):
 
 
 def test_make_partition_ids_by_ddi_scan_ms_min(ms_minimal_required):
-    from xradio.vis._vis_utils._ms.partition_queries import make_partition_ids_by_ddi_scan
+    from xradio.vis._vis_utils._ms.partition_queries import (
+        make_partition_ids_by_ddi_scan,
+    )
 
     res = make_partition_ids_by_ddi_scan(ms_minimal_required.fname, do_subscans=False)
 
     nddis = ms_minimal_required.descr["nddis"]
-    exp = (np.arange(nddis, dtype=np.int32), np.ones(nddis, dtype=np.int32), nddis*[None])
+    exp = (
+        np.arange(nddis, dtype=np.int32),
+        np.ones(nddis, dtype=np.int32),
+        nddis * [None],
+    )
     assert res
     assert np.allclose(res[0], exp[0])
     assert np.allclose(res[1], exp[1])
@@ -31,13 +39,19 @@ def test_make_partition_ids_by_ddi_scan_ms_min(ms_minimal_required):
 
 
 def test_make_partition_ids_by_ddi_scan_subs(ms_empty_required):
-    from xradio.vis._vis_utils._ms.partition_queries import make_partition_ids_by_ddi_scan
+    from xradio.vis._vis_utils._ms.partition_queries import (
+        make_partition_ids_by_ddi_scan,
+    )
 
     res = make_partition_ids_by_ddi_scan(ms_empty_required.fname, do_subscans=True)
 
-    exp = ([], np.array([], dtype=np.int32), np.array([], dtype=np.int32))
+    exp = (
+        np.array([], dtype=np.int32),
+        np.array([], dtype=np.int32),
+        np.array([], dtype=np.int32),
+    )
     assert res
-    assert res[0] == exp[0]
+    assert np.array_equal(res[0], exp[0])
     assert np.allclose(res[1], exp[1])
     assert np.allclose(res[2], exp[2])
 
@@ -62,44 +76,55 @@ def test_find_distinct_obs_mode(ms_minimal_required):
         assert res
 
 
-@pytest.mark.parametrize("mixed_intents_no_wvr, expected_results", [
-    ("OBSERVE_TARGET#ON_SOURCE,POSITION_SWITCH", ["OBSERVE_TARGET#ON_SOURCE,POSITION_SWITCH"]),
-    ("OBSERVE_TARGET#ON_SOURCE", ["OBSERVE_TARGET#ON_SOURCE"]),
-])
+@pytest.mark.parametrize(
+    "mixed_intents_no_wvr, expected_results",
+    [
+        (
+            "OBSERVE_TARGET#ON_SOURCE,POSITION_SWITCH",
+            ["OBSERVE_TARGET#ON_SOURCE,POSITION_SWITCH"],
+        ),
+        ("OBSERVE_TARGET#ON_SOURCE", ["OBSERVE_TARGET#ON_SOURCE"]),
+    ],
+)
 def test_filter_intents_per_ddi(mixed_intents_no_wvr, expected_results):
     from xradio.vis._vis_utils._ms.partition_queries import filter_intents_per_ddi
 
-    spw_name_by_ddi = {0: "WVR#NOMINAL",
-                       1: "ALMA_R_B03#BB_1#SW-01#FULL_RES",
-                       }
+    spw_name_by_ddi = {
+        0: "WVR#NOMINAL",
+        1: "ALMA_R_B03#BB_1#SW-01#FULL_RES",
+    }
 
-    res = filter_intents_per_ddi([0], "WVR", mixed_intents_no_wvr,
-                                 spw_name_by_ddi)
+    res = filter_intents_per_ddi([0], "WVR", mixed_intents_no_wvr, spw_name_by_ddi)
     assert res == expected_results
 
 
-@pytest.mark.parametrize("mixed_intents_wvr, expected_results", [
-    ("CALIBRATE#BANDPASS,CALIBRATE#WVR", ["CALIBRATE#WVR"]),
-    ("CALIBRATE_ATMOSPHERE#OFF_SOURCE,CALIBRATE_WVR#OFF_SOURCE",
-     ["CALIBRATE_WVR#OFF_SOURCE"]),
-])
+@pytest.mark.parametrize(
+    "mixed_intents_wvr, expected_results",
+    [
+        ("CALIBRATE#BANDPASS,CALIBRATE#WVR", ["CALIBRATE#WVR"]),
+        (
+            "CALIBRATE_ATMOSPHERE#OFF_SOURCE,CALIBRATE_WVR#OFF_SOURCE",
+            ["CALIBRATE_WVR#OFF_SOURCE"],
+        ),
+    ],
+)
 def test_filter_intents_per_ddi_wvr(mixed_intents_wvr, expected_results):
     from xradio.vis._vis_utils._ms.partition_queries import filter_intents_per_ddi
 
-    spw_name_by_ddi = {0: "WVR#NOMINAL",
-                       1: "ALMA_R_B03#BB_1#SW-01#FULL_RES",
-                       2: "ALMA_R_B03#BB_1#SW-01#CH_AVG",
-                       3: "ALMA_R_B03#BB_2#SW-01#FULL_RES",
-                       4: "ALMA_R_B03#BB_2#SW-01#CH_AVG",
-                       5: "ALMA_R_B03#BB_3#SW-01#FULL_RES",
-                       6: "ALMA_R_B03#BB_3#SW-01#CH_AVG",
-                       7: "ALMA_R_B03#BB_4#SW-01#FULL_RES",
-                       8: "ALMA_R_B03#BB_4#SW-01#CH_AVG",
-                       }
-    
+    spw_name_by_ddi = {
+        0: "WVR#NOMINAL",
+        1: "ALMA_R_B03#BB_1#SW-01#FULL_RES",
+        2: "ALMA_R_B03#BB_1#SW-01#CH_AVG",
+        3: "ALMA_R_B03#BB_2#SW-01#FULL_RES",
+        4: "ALMA_R_B03#BB_2#SW-01#CH_AVG",
+        5: "ALMA_R_B03#BB_3#SW-01#FULL_RES",
+        6: "ALMA_R_B03#BB_3#SW-01#CH_AVG",
+        7: "ALMA_R_B03#BB_4#SW-01#FULL_RES",
+        8: "ALMA_R_B03#BB_4#SW-01#CH_AVG",
+    }
+
     with pytest.raises(KeyError, match="0"):
-        res = filter_intents_per_ddi([0], "WVR", mixed_intents_wvr,
-                                     {})
+        res = filter_intents_per_ddi([0], "WVR", mixed_intents_wvr, {})
 
     res = filter_intents_per_ddi([0], "WVR", mixed_intents_wvr, spw_name_by_ddi)
     assert res == expected_results
@@ -116,7 +141,9 @@ def test_make_ddi_state_intent_lists():
 
 
 def test_make_partition_ids_by_ddi_intent_empty(ms_empty_required):
-    from xradio.vis._vis_utils._ms.partition_queries import make_partition_ids_by_ddi_intent
+    from xradio.vis._vis_utils._ms.partition_queries import (
+        make_partition_ids_by_ddi_intent,
+    )
 
     res = make_partition_ids_by_ddi_intent(ms_empty_required.fname, xr.Dataset())
 
@@ -129,13 +156,19 @@ def test_make_partition_ids_by_ddi_intent_empty(ms_empty_required):
 
 
 def test_make_partition_ids_by_ddi_intent_min(ms_minimal_required):
-    from xradio.vis._vis_utils._ms.partition_queries import make_partition_ids_by_ddi_intent
+    from xradio.vis._vis_utils._ms.partition_queries import (
+        make_partition_ids_by_ddi_intent,
+    )
 
     res = make_partition_ids_by_ddi_intent(ms_minimal_required.fname, xr.Dataset())
-    
+
     nddis = ms_minimal_required.descr["nddis"]
-    exp = (np.arange(nddis, dtype=np.int32), nddis*[None], nddis*[np.array([0, 1])],
-           nddis*['scan_intent#subscan_intent'])
+    exp = (
+        np.arange(nddis, dtype=np.int32),
+        nddis * [None],
+        nddis * [np.array([0, 1])],
+        nddis * ["scan_intent#subscan_intent"],
+    )
 
     assert res
     assert np.allclose(res[0], exp[0])
@@ -148,13 +181,21 @@ def test_make_partition_ids_by_ddi_intent_min(ms_minimal_required):
 
 @pytest.mark.uses_gdown
 def test_make_partition_ids_by_ddi_intent_vlass(ms_vlass_subset_evla_36473386):
-    from xradio.vis._vis_utils._ms.partition_queries import make_partition_ids_by_ddi_intent
+    from xradio.vis._vis_utils._ms.partition_queries import (
+        make_partition_ids_by_ddi_intent,
+    )
 
-    res = make_partition_ids_by_ddi_intent(ms_vlass_subset_evla_36473386.fname, xr.Dataset())
+    res = make_partition_ids_by_ddi_intent(
+        ms_vlass_subset_evla_36473386.fname, xr.Dataset()
+    )
 
     nddis = 2
-    exp = (np.arange(nddis), nddis*[None], np.arange(4, 223),
-           ['OBSERVE_TARGET#UNSPECIFIED', 'OBSERVE_TARGET#UNSPECIFIED'])
+    exp = (
+        np.arange(nddis),
+        nddis * [None],
+        np.arange(4, 223),
+        ["OBSERVE_TARGET#UNSPECIFIED", "OBSERVE_TARGET#UNSPECIFIED"],
+    )
     assert res
     assert np.allclose(res[0], exp[0])
     assert res[1] == exp[1]

--- a/tests/unit/vis/_vis_utils/_ms/test_partition_queries.py
+++ b/tests/unit/vis/_vis_utils/_ms/test_partition_queries.py
@@ -179,14 +179,14 @@ def test_make_partition_ids_by_ddi_intent_min(ms_minimal_required):
     assert res[3] == exp[3]
 
 
-@pytest.mark.uses_gdown
-def test_make_partition_ids_by_ddi_intent_vlass(ms_vlass_subset_evla_36473386):
+@pytest.mark.uses_download
+def test_make_partition_ids_by_ddi_intent_antennae(ms_alma_antennae_north_split):
     from xradio.vis._vis_utils._ms.partition_queries import (
         make_partition_ids_by_ddi_intent,
     )
 
     res = make_partition_ids_by_ddi_intent(
-        ms_vlass_subset_evla_36473386.fname, xr.Dataset()
+        ms_alma_antennae_north_split.fname, xr.Dataset()
     )
 
     nddis = 1

--- a/tests/unit/vis/_vis_utils/_ms/test_partitions.py
+++ b/tests/unit/vis/_vis_utils/_ms/test_partitions.py
@@ -1,0 +1,99 @@
+import numpy as np
+import pytest
+
+
+def test_make_spw_names_by_ddi():
+    from xradio.vis._vis_utils._ms.partitions import make_spw_names_by_ddi
+    import xarray
+
+    with pytest.raises(
+        AttributeError, match="object has no attribute 'spectral_window_id'"
+    ):
+        res = make_spw_names_by_ddi(xarray.Dataset(), xarray.Dataset())
+        assert res
+
+
+def test_make_spw_names_by_ddi_min(ddi_xds_min, spw_xds_min):
+    from xradio.vis._vis_utils._ms.partitions import make_spw_names_by_ddi
+    
+    res = make_spw_names_by_ddi(ddi_xds_min, spw_xds_min)
+    assert res
+    nddis = 4
+    assert np.all(np.arange(nddis) == sorted(res.keys()))
+    # exp_names = {0: 'unspecified_test#0', 1: 'unspecified_test#0', 2: 'unspecified_test#0', 3: 'unspecified_test#0', 4: 'unspecified_test#1', 5: 'unspecified_test#1', 6: 'unspecified_test#1', 7: 'unspecified_test#1'}
+    exp_names = {0: 'unspecified_test#0', 1: 'unspecified_test#0',
+                 2: 'unspecified_test#1', 3: 'unspecified_test#1'}
+    assert res == exp_names
+
+
+def test_make_spw_names_by_ddi_min_only_ddi(ddi_xds_min):
+    from xradio.vis._vis_utils._ms.partitions import make_spw_names_by_ddi
+    import xarray
+
+    with pytest.raises(
+            AttributeError, match="object has no attribute 'name'"):
+        res = make_spw_names_by_ddi(ddi_xds_min, xarray.Dataset())
+        assert res
+
+
+def test_make_spw_names_by_ddi_min_only_spw(spw_xds_min):
+    from xradio.vis._vis_utils._ms.partitions import make_spw_names_by_ddi
+    import xarray
+
+    with pytest.raises(
+            AttributeError, match="object has no attribute 'spectral_window_id'"):
+        res = make_spw_names_by_ddi(xarray.Dataset(), spw_xds_min)
+        assert res
+
+
+@pytest.mark.parametrize("intents, expected_results", [
+    ("OBSERVE_TARGET#ON_SOURCE,POSITION_SWITCH", {"OBSERVE_TARGET": ["ON_SOURCE"], "POSITION_SWITCH": [""]}),
+    ("OBSERVE_TARGET#UNSPECIFIED", {"OBSERVE_TARGET": ["UNSPECIFIED"]}),
+    ("CALIBRATE_DELAY#ON_SOURCE,CALIBRATE_PHASE#ON_SOURCE",
+     {"CALIBRATE_DELAY": ["ON_SOURCE"], "CALIBRATE_PHASE": ["ON_SOURCE"]}),
+    ("CALIBRATE_ATMOSPHERE#OFF_SOURCE,CALIBRATE_ATMOSPHERE#ON_SOURCE,CALIBRATE_WVR#OFF_SOURCE,CALIBRATE_WVR#ON_SOURCE",
+     {"CALIBRATE_ATMOSPHERE": ["OFF_SOURCE", "ON_SOURCE"],
+      "CALIBRATE_WVR": ["OFF_SOURCE", "ON_SOURCE"]}),
+    ("OBSERVE_TARGET.UNSPECIFIED", {"OBSERVE_TARGET": ["UNSPECIFIED"]}),
+    ("CALIBRATE_DELAY.ON_SOURCE,CALIBRATE_PHASE.ON_SOURCE",
+     {"CALIBRATE_DELAY": ["ON_SOURCE"], "CALIBRATE_PHASE": ["ON_SOURCE"]}),
+])
+def test_split_intents(intents, expected_results):
+    from xradio.vis._vis_utils._ms.partitions import split_intents
+
+    split_intents = split_intents(intents)
+    assert split_intents == expected_results
+
+
+def test_make_part_key():
+    from xradio.vis._vis_utils._ms.partitions import make_part_key
+    import xarray
+
+    with pytest.raises(KeyError, match="partition_ids"):
+        res = make_part_key(xarray.Dataset(), partition_scheme="intent")
+        assert res
+
+
+def test_read_ms_scan_subscan_partitions(ms_empty_required):
+    from xradio.vis._vis_utils._ms.partitions import read_ms_scan_subscan_partitions
+
+    with pytest.raises(
+        AttributeError, match="object has no attribute 'spectral_window_id'"
+    ):
+        res = read_ms_scan_subscan_partitions(ms_empty_required.fname, "intent")
+        assert res
+
+
+def test_read_ms_ddi_partitions(ms_empty_required):
+    from xradio.vis._vis_utils._ms.partitions import read_ms_ddi_partitions
+
+    with pytest.raises(AttributeError, match="Dataset' object has no attribute 'row'"):
+        res = read_ms_ddi_partitions(ms_empty_required.fname)
+        assert res
+
+
+def test_finalize_partitions():
+    from xradio.vis._vis_utils._ms.partitions import finalize_partitions
+
+    res = finalize_partitions({}, {})
+    assert res == {}

--- a/tests/unit/vis/_vis_utils/_ms/test_subtables.py
+++ b/tests/unit/vis/_vis_utils/_ms/test_subtables.py
@@ -1,0 +1,28 @@
+import pytest
+
+
+## Tests for _vis_utils/_ms/subtables functions. Move to its own file
+def test_subtables_read_ms_subtables_required(ms_empty_required):
+    from xradio.vis._vis_utils._ms.subtables import read_ms_subtables
+
+    res = read_ms_subtables(ms_empty_required.fname, done_subt=[])
+    assert res == {}
+
+
+def test_subtables_read_ms_subtables_complete(ms_empty_complete):
+    from xradio.vis._vis_utils._ms.subtables import read_ms_subtables
+
+    res = read_ms_subtables(ms_empty_complete.fname, done_subt=[])
+    assert res == {}
+
+
+def test_subtables_pointing_to_partition():
+    from xradio.vis._vis_utils._ms.subtables import add_pointing_to_partition
+    import xarray
+
+    with pytest.raises(
+        AttributeError, match="'Dataset' object has no attribute 'time'"
+    ):
+        res = add_pointing_to_partition(xarray.Dataset(), xarray.Dataset())
+        assert res
+

--- a/tests/unit/vis/_vis_utils/_utils/test_cds.py
+++ b/tests/unit/vis/_vis_utils/_utils/test_cds.py
@@ -1,0 +1,12 @@
+
+def test_cds():
+    from xradio.vis._vis_utils._utils.xds_helper import CASAVisSet
+    descr = "any"
+    cds = CASAVisSet({}, {}, "any")
+    assert cds["metainfo"] == {}
+    assert cds["partitions"] == {}
+    assert cds["descr"] == descr
+    assert print(cds) == None
+    expected_keywords = ["metainfo", "partitions", "descr"]
+    assert all([key in cds.__repr__() for key in expected_keywords])
+    assert all([key in cds._repr_html_() for key in expected_keywords])

--- a/tests/unit/vis/_vis_utils/_utils/test_xds_helper.py
+++ b/tests/unit/vis/_vis_utils/_utils/test_xds_helper.py
@@ -185,9 +185,7 @@ def test_calc_otimal_ms_chunk_shape_raises(
 def test_optimal_chunking(ndim, didxs, chunk_size, data_shape, expected_res):
     from xradio.vis._vis_utils._utils.xds_helper import optimal_chunking
 
-    # ndim = 4
-    # didxs = None
-    # chunk_size = "auto"
-    # data_shape = (10, 20, 200, 2)
     res = optimal_chunking(ndim, didxs, chunk_size, data_shape)
-    assert res == expected_res
+    # This can depend heavily on mem available on the machine
+    if data_shape:
+        assert res <= data_shape

--- a/tests/unit/vis/_vis_utils/_utils/test_xds_helper.py
+++ b/tests/unit/vis/_vis_utils/_utils/test_xds_helper.py
@@ -21,9 +21,7 @@ def test_partitions_make_coords_min(ant_xds_min, ddi_xds_min, spw_xds_min, pol_x
 
     with pytest.raises(AttributeError, match="object has no attribute 'freq'"):
         res = make_coords(
-            xarray.Dataset(),
-            0,
-            (ant_xds_min, ddi_xds_min, spw_xds_min, pol_xds_min)
+            xarray.Dataset(), 0, (ant_xds_min, ddi_xds_min, spw_xds_min, pol_xds_min)
         )
         assert res
 
@@ -32,7 +30,7 @@ def test_vis_xds_packager_cds(ant_xds_min):
     from xradio.vis._vis_utils._utils.xds_helper import vis_xds_packager_cds
 
     addt = "addition"
-    subts =[("antenna", ant_xds_min)]
+    subts = [("antenna", ant_xds_min)]
     parts = {9: 0}
     res = vis_xds_packager_cds(subts, parts, addt)
     assert res
@@ -45,11 +43,11 @@ def test_vis_xds_packager_mxds(ant_xds_min):
     from xarray.core.utils import Frozen
 
     addt = "addition"
-    subts =[("antenna", ant_xds_min)]
+    subts = [("antenna", ant_xds_min)]
     parts = {9: 0}
     res = vis_xds_packager_mxds(parts, subts, addt)
     assert res.data_vars == {}
-    assert res.dims == Frozen({})
+    assert res.sizes == Frozen({})
     assert res.attrs["metainfo"] == [("antenna", ant_xds_min)]
     assert res.attrs["partitions"] == parts
 
@@ -71,10 +69,11 @@ def test_make_global_coords_min(ms_minimal_required):
     # TODO: fixture forf an xds (main) + a cds fixture
     cds = read_ms(ms_minimal_required.fname, partition_scheme="ddi")
     # xds = list(cds.partitions.values())[0]
-    mxds = xarray.Dataset(attrs={"metainfo": cds.metainfo,
-                                 "partitions": {}})
+    mxds = xarray.Dataset(attrs={"metainfo": cds.metainfo, "partitions": {}})
 
-    with pytest.raises(ValueError, match="different number of dimensions on data and dims"):
+    with pytest.raises(
+        ValueError, match="different number of dimensions on data and dims"
+    ):
         res = make_global_coords(mxds)
         assert res
 
@@ -115,24 +114,33 @@ def test_flatten_xds_main_min(main_xds_min):
     from xradio.vis._vis_utils._utils.xds_helper import expand_xds
 
     res = flatten_xds(main_xds_min)
-    assert [dim in res.dims for dim in ["row", "uvw_coords", "freq", "pol", "antenna_id"]]
+    assert [
+        dim in res.dims for dim in ["row", "uvw_coords", "freq", "pol", "antenna_id"]
+    ]
     # A separate test/fixture would be better?
     print(f" Thse are {res.dims=}, {res.coords=}")
     print(f" This is {res.data_vars=}")
     res = res.drop_vars("baseline")
-    #with pytest.raises(AttributeError, "has no attribute"
+    # with pytest.raises(AttributeError, "has no attribute"
     res_expanded = expand_xds(res)
 
 
 BYTES_TO_GB = 1024 * 1024 * 1204
-@pytest.mark.parametrize("mem_avail, shape, elem_size, col_name, expected_res", [
-    (6 * BYTES_TO_GB, (100, 28, 200, 2), 4, "any name", 100),
-    (4 * BYTES_TO_GB, (1000, 28, 4000, 4), 4, "other name", 1000),
-    (8 * BYTES_TO_GB, (3600, 28, 10000, 4), 8, "name", 901),
-    (8 * BYTES_TO_GB, (10000, 300, 20000, 2), 8, "name", 84),
-    (4 * BYTES_TO_GB, (10000, 946, 20000, 4), 8, "name", 6),
-])
-def test_calc_otimal_ms_chunk_shape(mem_avail, shape, elem_size, col_name, expected_res):
+
+
+@pytest.mark.parametrize(
+    "mem_avail, shape, elem_size, col_name, expected_res",
+    [
+        (6 * BYTES_TO_GB, (100, 28, 200, 2), 4, "any name", 100),
+        (4 * BYTES_TO_GB, (1000, 28, 4000, 4), 4, "other name", 1000),
+        (8 * BYTES_TO_GB, (3600, 28, 10000, 4), 8, "name", 901),
+        (8 * BYTES_TO_GB, (10000, 300, 20000, 2), 8, "name", 84),
+        (4 * BYTES_TO_GB, (10000, 946, 20000, 4), 8, "name", 6),
+    ],
+)
+def test_calc_otimal_ms_chunk_shape(
+    mem_avail, shape, elem_size, col_name, expected_res
+):
     import numbers
     from xradio.vis._vis_utils._utils.xds_helper import calc_optimal_ms_chunk_shape
 
@@ -140,25 +148,40 @@ def test_calc_otimal_ms_chunk_shape(mem_avail, shape, elem_size, col_name, expec
     assert res == expected_res
 
 
-@pytest.mark.parametrize("mem_avail, shape, elem_size, col_name, expected_raises", [
-    (6 * BYTES_TO_GB, (100, 28, 200, 2), 4, "any name", does_not_raise()),
-    (4 * BYTES_TO_GB, (100, 946, 200000, 4), 8, "name", pytest.raises(RuntimeError)),
-])
-def test_calc_otimal_ms_chunk_shape_raises(mem_avail, shape, elem_size, col_name, expected_raises):
+@pytest.mark.parametrize(
+    "mem_avail, shape, elem_size, col_name, expected_raises",
+    [
+        (6 * BYTES_TO_GB, (100, 28, 200, 2), 4, "any name", does_not_raise()),
+        (
+            4 * BYTES_TO_GB,
+            (100, 946, 200000, 4),
+            8,
+            "name",
+            pytest.raises(RuntimeError),
+        ),
+    ],
+)
+def test_calc_otimal_ms_chunk_shape_raises(
+    mem_avail, shape, elem_size, col_name, expected_raises
+):
     import numbers
     from xradio.vis._vis_utils._utils.xds_helper import calc_optimal_ms_chunk_shape
+
     with expected_raises:
         res = calc_optimal_ms_chunk_shape(mem_avail, shape, elem_size, col_name)
 
 
 # likely to be very flaky depending on machine resources. Let's see
-@pytest.mark.parametrize("ndim, didxs, chunk_size, data_shape, expected_res", [
-    (4, None, "auto", (10, 20, 200, 2), (10, 20, 200, 2)),
-    (3, None, "auto", (3600, 30, 2000), (1705, 14, 947)),
-    (4, None, "large", (5000, 30, 4000, 1), (3010, 19, 2408, 1)),
-    (4, None, "small", (100, 30, 2000, 2), (100, 30, 2000, 2)),
-    (4, None, "small", None, (284, 284, 284, 1)),
-])
+@pytest.mark.parametrize(
+    "ndim, didxs, chunk_size, data_shape, expected_res",
+    [
+        (4, None, "auto", (10, 20, 200, 2), (10, 20, 200, 2)),
+        (3, None, "auto", (3600, 30, 2000), (1705, 14, 947)),
+        (4, None, "large", (5000, 30, 4000, 1), (3010, 19, 2408, 1)),
+        (4, None, "small", (100, 30, 2000, 2), (100, 30, 2000, 2)),
+        (4, None, "small", None, (284, 284, 284, 1)),
+    ],
+)
 def test_optimal_chunking(ndim, didxs, chunk_size, data_shape, expected_res):
     from xradio.vis._vis_utils._utils.xds_helper import optimal_chunking
 

--- a/tests/unit/vis/_vis_utils/_utils/test_xds_helper.py
+++ b/tests/unit/vis/_vis_utils/_utils/test_xds_helper.py
@@ -1,0 +1,170 @@
+from contextlib import nullcontext as does_not_raise
+import pytest
+
+import xarray
+
+
+def test_partitions_make_coords():
+    from xradio.vis._vis_utils._utils.xds_helper import make_coords
+
+    with pytest.raises(AttributeError, match="object has no attribute 'chan_freq'"):
+        res = make_coords(
+            xarray.Dataset(),
+            0,
+            (xarray.Dataset(), xarray.Dataset, xarray.Dataset(), xarray.Dataset()),
+        )
+        assert res
+
+
+def test_partitions_make_coords_min(ant_xds_min, ddi_xds_min, spw_xds_min, pol_xds_min):
+    from xradio.vis._vis_utils._utils.xds_helper import make_coords
+
+    with pytest.raises(AttributeError, match="object has no attribute 'freq'"):
+        res = make_coords(
+            xarray.Dataset(),
+            0,
+            (ant_xds_min, ddi_xds_min, spw_xds_min, pol_xds_min)
+        )
+        assert res
+
+
+def test_vis_xds_packager_cds(ant_xds_min):
+    from xradio.vis._vis_utils._utils.xds_helper import vis_xds_packager_cds
+
+    addt = "addition"
+    subts =[("antenna", ant_xds_min)]
+    parts = {9: 0}
+    res = vis_xds_packager_cds(subts, parts, addt)
+    assert res
+    assert res.metainfo == [("antenna", ant_xds_min)]
+    assert res.partitions == parts
+
+
+def test_vis_xds_packager_mxds(ant_xds_min):
+    from xradio.vis._vis_utils._utils.xds_helper import vis_xds_packager_mxds
+    from xarray.core.utils import Frozen
+
+    addt = "addition"
+    subts =[("antenna", ant_xds_min)]
+    parts = {9: 0}
+    res = vis_xds_packager_mxds(parts, subts, addt)
+    assert res.data_vars == {}
+    assert res.dims == Frozen({})
+    assert res.attrs["metainfo"] == [("antenna", ant_xds_min)]
+    assert res.attrs["partitions"] == parts
+
+
+def test_make_global_coords_none():
+    from xradio.vis._vis_utils._utils.xds_helper import make_global_coords
+
+    with pytest.raises(KeyError, match="metainfo"):
+        res = make_global_coords(xarray.Dataset())
+        assert res
+
+
+def test_make_global_coords_min(ms_minimal_required):
+    from xradio.vis._vis_utils._utils.xds_helper import make_global_coords
+    from xradio.vis._vis_utils._utils.xds_helper import vis_xds_packager_mxds
+
+    from xradio.vis._vis_utils.ms import read_ms
+
+    # TODO: fixture forf an xds (main) + a cds fixture
+    cds = read_ms(ms_minimal_required.fname, partition_scheme="ddi")
+    # xds = list(cds.partitions.values())[0]
+    mxds = xarray.Dataset(attrs={"metainfo": cds.metainfo,
+                                 "partitions": {}})
+
+    with pytest.raises(ValueError, match="different number of dimensions on data and dims"):
+        res = make_global_coords(mxds)
+        assert res
+
+
+def test_expand_xds():
+    from xradio.vis._vis_utils._utils.xds_helper import expand_xds
+
+    empty = xarray.Dataset()
+    with pytest.raises(AttributeError, match="object has no attribute"):
+        res = expand_xds(empty)
+        assert "baseline" in res.data_vars
+
+
+def test_expand_xds_ddi_min(ms_minimal_required):
+    from xradio.vis._vis_utils._utils.xds_helper import expand_xds
+    from xradio.vis._vis_utils.ms import read_ms
+
+    # TODO: fixture for an xds (main)
+    cds = read_ms(ms_minimal_required.fname, partition_scheme="ddi", expand=False)
+    xds = list(cds.partitions.values())[0]
+
+    with pytest.raises(AssertionError, match=""):
+        res = expand_xds(xds)
+        assert res
+        assert "baseline" in res.coords
+
+
+def test_flatten_xds_empty():
+    from xradio.vis._vis_utils._utils.xds_helper import flatten_xds
+
+    empty = xarray.Dataset()
+    res = flatten_xds(empty)
+    assert xarray.Dataset.equals(res, empty)
+
+
+def test_flatten_xds_main_min(main_xds_min):
+    from xradio.vis._vis_utils._utils.xds_helper import flatten_xds
+    from xradio.vis._vis_utils._utils.xds_helper import expand_xds
+
+    res = flatten_xds(main_xds_min)
+    assert [dim in res.dims for dim in ["row", "uvw_coords", "freq", "pol", "antenna_id"]]
+    # A separate test/fixture would be better?
+    print(f" Thse are {res.dims=}, {res.coords=}")
+    print(f" This is {res.data_vars=}")
+    res = res.drop_vars("baseline")
+    #with pytest.raises(AttributeError, "has no attribute"
+    res_expanded = expand_xds(res)
+
+
+BYTES_TO_GB = 1024 * 1024 * 1204
+@pytest.mark.parametrize("mem_avail, shape, elem_size, col_name, expected_res", [
+    (6 * BYTES_TO_GB, (100, 28, 200, 2), 4, "any name", 100),
+    (4 * BYTES_TO_GB, (1000, 28, 4000, 4), 4, "other name", 1000),
+    (8 * BYTES_TO_GB, (3600, 28, 10000, 4), 8, "name", 901),
+    (8 * BYTES_TO_GB, (10000, 300, 20000, 2), 8, "name", 84),
+    (4 * BYTES_TO_GB, (10000, 946, 20000, 4), 8, "name", 6),
+])
+def test_calc_otimal_ms_chunk_shape(mem_avail, shape, elem_size, col_name, expected_res):
+    import numbers
+    from xradio.vis._vis_utils._utils.xds_helper import calc_optimal_ms_chunk_shape
+
+    res = calc_optimal_ms_chunk_shape(mem_avail, shape, elem_size, col_name)
+    assert res == expected_res
+
+
+@pytest.mark.parametrize("mem_avail, shape, elem_size, col_name, expected_raises", [
+    (6 * BYTES_TO_GB, (100, 28, 200, 2), 4, "any name", does_not_raise()),
+    (4 * BYTES_TO_GB, (100, 946, 200000, 4), 8, "name", pytest.raises(RuntimeError)),
+])
+def test_calc_otimal_ms_chunk_shape_raises(mem_avail, shape, elem_size, col_name, expected_raises):
+    import numbers
+    from xradio.vis._vis_utils._utils.xds_helper import calc_optimal_ms_chunk_shape
+    with expected_raises:
+        res = calc_optimal_ms_chunk_shape(mem_avail, shape, elem_size, col_name)
+
+
+# likely to be very flaky depending on machine resources. Let's see
+@pytest.mark.parametrize("ndim, didxs, chunk_size, data_shape, expected_res", [
+    (4, None, "auto", (10, 20, 200, 2), (10, 20, 200, 2)),
+    (3, None, "auto", (3600, 30, 2000), (1705, 14, 947)),
+    (4, None, "large", (5000, 30, 4000, 1), (3010, 19, 2408, 1)),
+    (4, None, "small", (100, 30, 2000, 2), (100, 30, 2000, 2)),
+    (4, None, "small", None, (284, 284, 284, 1)),
+])
+def test_optimal_chunking(ndim, didxs, chunk_size, data_shape, expected_res):
+    from xradio.vis._vis_utils._utils.xds_helper import optimal_chunking
+
+    # ndim = 4
+    # didxs = None
+    # chunk_size = "auto"
+    # data_shape = (10, 20, 200, 2)
+    res = optimal_chunking(ndim, didxs, chunk_size, data_shape)
+    assert res == expected_res

--- a/tests/unit/vis/_vis_utils/_zarr/test_read.py
+++ b/tests/unit/vis/_vis_utils/_zarr/test_read.py
@@ -1,0 +1,110 @@
+import pytest
+
+
+def test_read_part_keys(ms_as_zarr_min):
+    from xradio.vis._vis_utils._zarr.read import read_part_keys
+
+    with pytest.raises(FileNotFoundError, match="No such file or directory"):
+        keys = read_part_keys(ms_as_zarr_min)
+        assert keys
+
+
+def test_read_subtables(ms_as_zarr_min):
+    from xradio.vis._vis_utils._zarr.read import read_subtables
+
+    with pytest.raises(FileNotFoundError, match="No such file or directory"):
+        subts = read_subtables(ms_as_zarr_min, asdm_subtables=True)
+        assert subts
+
+
+def teest_read_paritions(ms_as_zarr_min):
+    from xradio.vis._vis_utils._zarr.read import read_partitions
+
+    with pytest.raises(FileNotFoundError, match="No such file or directory"):
+        parts = read_partitions(ms_as_zarr_min, part_keys=[])
+        assert parts
+
+
+def test_read_xds(ms_as_zarr_min):
+    from xradio.vis._vis_utils._zarr.read import read_xds
+
+    with pytest.raises(KeyError, match="metadata"):
+        cds = read_xds(ms_as_zarr_min)
+        assert cds
+
+
+def test_read_zarr(ms_as_zarr_min):
+    from xradio.vis._vis_utils._zarr.read import read_zarr
+
+    with pytest.raises(FileNotFoundError, match="No such file or directory"):
+        cds = read_zarr(ms_as_zarr_min)
+        assert cds
+
+
+def test__fix_dict_for_ms(main_xds_min):
+    from xradio.vis._vis_utils._zarr.read import _fix_dict_for_ms
+    import copy
+
+    # Crude way of giving this function what it expects. Iterate.
+    xds = copy.deepcopy(main_xds_min)
+    xds.attrs["column_descriptions"] = xds.attrs["other"]["msv2"]["ctds_attrs"]["column_descriptions"]
+    with pytest.raises(AttributeError, match="has no attribut"):
+        res = _fix_dict_for_ms("xds_test", xds)
+        assert res
+
+def test__fix_dict_for_ms_spw(spw_xds_min):
+    from xradio.vis._vis_utils._zarr.read import _fix_dict_for_ms
+    from xradio.vis._vis_utils._zarr.write import prepare_attrs_for_zarr
+    import copy
+    
+    # Crude way of giving this function what it expects. Iterate.
+    preproc = prepare_attrs_for_zarr("spectral_window",
+                                     copy.deepcopy(spw_xds_min))
+    preproc.attrs["column_descriptions"] = preproc.attrs["other"]["msv2"]["ctds_attrs"]["column_descriptions"]
+    # with pytest.raises(KeyError, match="0"):
+    res = _fix_dict_for_ms("spectral_window", preproc)
+    assert res
+
+
+def test__fix_dict_for_ms_ant(ant_xds_min):
+    from xradio.vis._vis_utils._zarr.read import _fix_dict_for_ms
+    from xradio.vis._vis_utils._zarr.write import prepare_attrs_for_zarr
+    
+    # Crude way of giving this function what it expects. Iterate.
+    preproc = prepare_attrs_for_zarr("antenna", ant_xds_min)
+    preproc.attrs["column_descriptions"] = preproc.attrs["other"]["msv2"]["ctds_attrs"]["column_descriptions"]
+    res = _fix_dict_for_ms("antenna", preproc)
+    assert res
+
+
+def test__fix_dict_for_ms_field(field_xds_min):
+    from xradio.vis._vis_utils._zarr.read import _fix_dict_for_ms
+    from xradio.vis._vis_utils._zarr.write import prepare_attrs_for_zarr
+    
+    # Crude way of giving this function what it expects. Iterate.
+    preproc = prepare_attrs_for_zarr("field", field_xds_min)
+    preproc.attrs["column_descriptions"] = preproc.attrs["other"]["msv2"]["ctds_attrs"]["column_descriptions"]
+    res = _fix_dict_for_ms("field", preproc)
+    assert res
+
+
+def test__fix_dict_for_ms_feed(feed_xds_min):
+    from xradio.vis._vis_utils._zarr.read import _fix_dict_for_ms
+    from xradio.vis._vis_utils._zarr.write import prepare_attrs_for_zarr
+    
+    # Crude way of giving this function what it expects. Iterate.
+    preproc = prepare_attrs_for_zarr("feed", feed_xds_min)
+    preproc.attrs["column_descriptions"] = preproc.attrs["other"]["msv2"]["ctds_attrs"]["column_descriptions"]
+    res = _fix_dict_for_ms("feed", preproc)
+    assert res
+
+
+def test__fix_dict_for_ms_observation(observation_xds_min):
+    from xradio.vis._vis_utils._zarr.read import _fix_dict_for_ms
+    from xradio.vis._vis_utils._zarr.write import prepare_attrs_for_zarr
+    
+    # Crude way of giving this function what it expects. Iterate.
+    preproc = prepare_attrs_for_zarr("observation", observation_xds_min)
+    preproc.attrs["column_descriptions"] = preproc.attrs["other"]["msv2"]["ctds_attrs"]["column_descriptions"]
+    res = _fix_dict_for_ms("observation", preproc)
+    assert res

--- a/tests/unit/vis/_vis_utils/_zarr/test_write.py
+++ b/tests/unit/vis/_vis_utils/_zarr/test_write.py
@@ -1,0 +1,89 @@
+import pytest
+import tempfile
+
+def test_write_part_keys_empty():
+    from xradio.vis._vis_utils._zarr.write import write_part_keys
+    import xarray as xr
+
+    with pytest.raises(ValueError, match="not enough values to unpack"):
+        res = write_part_keys({}, "output_path", {})
+        assert res
+
+
+def test_write_part_keys_min(cds_minimal_required):
+    from xradio.vis._vis_utils._zarr.write import write_part_keys
+
+    res = write_part_keys(cds_minimal_required.partitions, "output_path", {})
+    assert res == None
+
+
+def test_write_metainfo_empty():
+    from xradio.vis._vis_utils._zarr.write import write_metainfo
+    import xarray as xr
+
+    with tempfile.TemporaryDirectory() as outname:
+        res = write_metainfo(outname, {})
+        assert not res
+
+
+def test_write_partitions_empty():
+    from xradio.vis._vis_utils._zarr.write import write_partitions
+    import xarray as xr
+
+    with tempfile.TemporaryDirectory() as outname:
+        res = write_partitions(outname, {})
+        assert not res
+
+
+def test_write_xds_to_zarr_empty():
+    from xradio.vis._vis_utils._zarr.write import write_xds_to_zarr
+    import xarray as xr
+
+    with pytest.raises(KeyError, match="other"):
+        res = write_xds_to_zarr(xr.Dataset(), "name", "output_path")
+        assert not res
+
+
+def test_write_xds_to_zarr_ant(ant_xds_min):
+    from xradio.vis._vis_utils._zarr.write import write_xds_to_zarr
+    import xarray as xr
+
+    res = write_xds_to_zarr(ant_xds_min, "antenna", "output_path")
+    assert not res
+
+
+def test_write_xds_to_zarr_pol(pol_xds_min):
+    from xradio.vis._vis_utils._zarr.write import write_xds_to_zarr
+    import xarray as xr
+
+    res = write_xds_to_zarr(pol_xds_min, "polarization", "output_path")
+    assert not res
+
+
+def test_write_xds_to_zarr_main_min(main_xds_min):
+    from xradio.vis._vis_utils._zarr.write import write_xds_to_zarr
+    import xarray as xr
+
+    # with pytest.raises(TypeError, match="Invalid attribute"):
+    res = write_xds_to_zarr(main_xds_min, "xds_main_test", "output_path",
+                            chunks_on_disk={"time": 20})
+    assert not res
+
+
+def test_prepare_attrs_for_zarr_empty():
+    from xradio.vis._vis_utils._zarr.write import prepare_attrs_for_zarr
+    import xarray as xr
+    
+    with pytest.raises(KeyError, match="other"):
+        res = prepare_attrs_for_zarr("empty/test", xr.Dataset())
+        assert res
+
+
+def test_prepare_attrs_for_zarr_main_min(main_xds_min):
+    from xradio.vis._vis_utils._zarr.write import prepare_attrs_for_zarr
+    import xarray as xr
+    
+    # TODO: very crude way of exercising corner-case filtering
+    main_xds_min.attrs["other"]["msv2"]["ctds_attrs"]["column_descriptions"]["TIME"]["keywords"]["CHANNEL_SELECTION"] = {}
+    res = prepare_attrs_for_zarr("xds_test", main_xds_min)
+    assert res

--- a/tests/unit/vis/_vis_utils/test_ms.py
+++ b/tests/unit/vis/_vis_utils/test_ms.py
@@ -3,21 +3,21 @@ import pytest
 from xradio.vis._vis_utils._utils.cds_checks import check_cds
 
 
-@pytest.mark.uses_gdown
-def test_read_vlass_ms_default(ms_vlass_subset_evla_36473386):
+@pytest.mark.uses_download
+def test_read_alma_ms_default(ms_alma_antennae_north_split):
     """ Read with default parameters ('intent' partitioning) """
     from xradio.vis._vis_utils.ms import read_ms
 
-    vis = read_ms(ms_vlass_subset_evla_36473386.fname)
+    vis = read_ms(ms_alma_antennae_north_split.fname)
     check_cds(vis)
 
 
-@pytest.mark.uses_gdown
-def test_read_vlass_ms_by_ddi(ms_vlass_subset_evla_36473386):
+@pytest.mark.uses_download
+def test_read_alma_ms_by_ddi(ms_alma_antennae_north_split):
     from xradio.vis._vis_utils.ms import read_ms
 
     scheme = "ddi"
-    vis = read_ms(ms_vlass_subset_evla_36473386.fname, partition_scheme=scheme)
+    vis = read_ms(ms_alma_antennae_north_split.fname, partition_scheme=scheme)
     check_cds(vis, partition_scheme=scheme)
 
 

--- a/tests/unit/vis/_vis_utils/test_ms.py
+++ b/tests/unit/vis/_vis_utils/test_ms.py
@@ -1,6 +1,6 @@
 import pytest
 
-from xradio.vis._vis_utils._utils.cds_checks import check_cds
+from tests.unit.vis.ms_test_utils.cds_checks import check_cds
 
 
 @pytest.mark.uses_download

--- a/tests/unit/vis/_vis_utils/test_ms.py
+++ b/tests/unit/vis/_vis_utils/test_ms.py
@@ -1,0 +1,119 @@
+import pytest
+
+from xradio.vis._vis_utils._utils.cds_checks import check_cds
+
+
+@pytest.mark.uses_gdown
+def test_read_vlass_ms_default(ms_vlass_subset_evla_36473386):
+    """ Read with default parameters ('intent' partitioning) """
+    from xradio.vis._vis_utils.ms import read_ms
+
+    vis = read_ms(ms_vlass_subset_evla_36473386.fname)
+    check_cds(vis)
+
+
+@pytest.mark.uses_gdown
+def test_read_vlass_ms_by_ddi(ms_vlass_subset_evla_36473386):
+    from xradio.vis._vis_utils.ms import read_ms
+
+    scheme = "ddi"
+    vis = read_ms(ms_vlass_subset_evla_36473386.fname, partition_scheme=scheme)
+    check_cds(vis, partition_scheme=scheme)
+
+
+def test_read_ms_by_scan_empty_required(ms_empty_required,
+                                        essential_subtables):
+    from xradio.vis._vis_utils.ms import read_ms
+
+    vis = read_ms(ms_empty_required.fname, partition_scheme="scan")
+    assert vis.metainfo
+    assert essential_subtables <= vis.metainfo.keys()
+
+
+def test_read_ms_by_scan_minimal(ms_minimal_required,
+                                 essential_subtables):
+    from xradio.vis._vis_utils.ms import read_ms
+
+    vis = read_ms(ms_minimal_required.fname, partition_scheme="scan")
+    assert vis.metainfo
+    assert essential_subtables <= vis.metainfo.keys()
+
+
+def test_read_ms_by_ddi_empty_required(ms_empty_required):
+    from xradio.vis._vis_utils.ms import read_ms
+
+    with pytest.raises(
+        AttributeError, match="object has no attribute 'row'"):
+        vis = read_ms(ms_empty_required.fname, partition_scheme="ddi")
+        assert vis.metainfo
+
+
+def test_read_ms_by_ddi_minimal(ms_minimal_required):
+    from xradio.vis._vis_utils.ms import read_ms
+
+    vis = read_ms(ms_minimal_required.fname, partition_scheme="ddi")
+    assert vis.metainfo
+
+
+def test_read_ms_by_intent_empty_required(ms_empty_required):
+    from xradio.vis._vis_utils.ms import read_ms
+
+    with pytest.raises(
+        AttributeError, match="object has no attribute"):
+        vis = read_ms(ms_empty_required.fname, partition_scheme="intent")
+        assert vis.metainfo
+
+
+def test_read_ms_by_intent_minimal(ms_minimal_required):
+    from xradio.vis._vis_utils.ms import read_ms
+
+    vis = read_ms(ms_minimal_required.fname, partition_scheme="intent")
+    assert vis.metainfo
+
+
+def test_read_ms_by_ddi_minimal_with_asdm(ms_minimal_required):
+    from xradio.vis._vis_utils.ms import read_ms
+
+    vis = read_ms(ms_minimal_required.fname, asdm_subtables=True, partition_scheme="ddi")
+    assert vis.metainfo
+
+
+def test_read_ms_by_ddi_with_expand(ms_minimal_required):
+    from xradio.vis._vis_utils.ms import read_ms
+
+    # TODO: fixture for an xds (main)
+    cds = read_ms(ms_minimal_required.fname, partition_scheme="ddi", expand=True)
+    assert cds
+
+
+def test_read_ms_by_scan_with_expand(ms_minimal_required):
+    from xradio.vis._vis_utils.ms import read_ms
+
+    # TODO: fixture for an xds (main)
+    cds = read_ms(ms_minimal_required.fname, partition_scheme="scan", expand=True)
+    assert cds
+
+
+def test_read_ms_by_intent_expand_raises(ms_minimal_required):
+    from xradio.vis._vis_utils.ms import read_ms
+
+    # TODO: fixture for an xds (main)
+    with pytest.raises(RuntimeError, match="Error in TaQL command"):
+        cds = read_ms(ms_minimal_required.fname, partition_scheme="intent", expand=True)
+        assert cds
+
+
+# def test_load_vis_chunk_empty_required(ms_empty_required):
+#     from xradio.vis._vis_utils.ms import load_vis_chunk
+
+#     chunk = {
+#         "time": slice(0, 8),
+#         "baseline": slice(0, 10),
+#         "freq": slice(0, 40),
+#         "pol": slice(0, 2),
+#     }
+
+#     vis = load_vis_chunk(ms_empty_required, chunk, (0, 0, 'intent'))
+#     assert vis
+#     assert vis.partitions
+#     assert vis.metainfo == {}

--- a/tests/unit/vis/_vis_utils/test_zarr.py
+++ b/tests/unit/vis/_vis_utils/test_zarr.py
@@ -1,4 +1,5 @@
 import os, shutil, tempfile
+from pathlib import Path
 import pytest
 
 
@@ -7,13 +8,15 @@ def clear_output(path):
         shutil.rmtree(path)
 
 
-def test_zarr_write_vis_empty():
+def test_zarr_write_vis_empty(tmp_path):
     from xradio.vis._vis_utils._utils.cds import CASAVisSet
     from xradio.vis._vis_utils.zarr import write_vis
     import xarray
 
-    cds = CASAVisSet({}, {(0, 0, "intent#subintent"): xarray.Dataset()}, "empty vis set")
-    outname = "test_vis_empty.zarr"
+    cds = CASAVisSet(
+        {}, {(0, 0, "intent#subintent"): xarray.Dataset()}, "empty vis set"
+    )
+    outname = str(Path(tmp_path, "test_vis_empty.zarr"))
     with pytest.raises(KeyError, match="other"):
         clear_output(outname)
         write_vis(cds, outname)
@@ -27,26 +30,27 @@ def test_zarr_write_exists():
             res = write_vis({}, outname)
 
 
-def test_zarr_write_ms_minimal(cds_minimal_required):
+def test_zarr_write_ms_minimal(cds_minimal_required, tmp_path):
     from xradio.vis import read_vis
     from xradio.vis._vis_utils.zarr import write_vis
     import copy
 
-    outname = "test_vis_min_write.zarr"
+    outname = Path(tmp_path, "test_vis_min_write.zarr")
     clear_output(outname)
     cds = copy.deepcopy(cds_minimal_required)
     write_vis(cds, outname)
 
     from xradio.vis._vis_utils.zarr import is_zarr_vis, read_vis
+
     res = is_zarr_vis(outname)
     assert res
     # TODO: move into a fixture/similar
     # @pytest.mark.depends(on=["test_zarr_write_ms_minimal"])
-    cds = read_vis("test_vis_min_write.zarr")
-    
-    
-def test_zarr_write_vis_attrs():
-    """ write to zarr (TODO: revisit) """
+    cds = read_vis(outname)
+
+
+def test_zarr_write_vis_attrs(tmp_path):
+    """write to zarr (TODO: revisit)"""
     from xradio.vis._vis_utils._utils.cds import CASAVisSet
     from xradio.vis._vis_utils.zarr import write_vis
     import xarray
@@ -55,7 +59,7 @@ def test_zarr_write_vis_attrs():
         attrs={"other": {"msv2": {"ctds_attrs": {"column_descriptions": {}}}}}
     )
     cds = CASAVisSet({}, {(0, 0, "intent"): empty_part}, "empty vis set")
-    outname = "test_vis_empty.zarr"
+    outname = str(Path(tmp_path, "test_vis_empty.zarr"))
     with pytest.raises(KeyError, match="UVW"):
         clear_output(outname)
         write_vis(cds, outname)

--- a/tests/unit/vis/_vis_utils/test_zarr.py
+++ b/tests/unit/vis/_vis_utils/test_zarr.py
@@ -1,0 +1,61 @@
+import os, shutil, tempfile
+import pytest
+
+
+def clear_output(path):
+    if os.path.lexists(path):
+        shutil.rmtree(path)
+
+
+def test_zarr_write_vis_empty():
+    from xradio.vis._vis_utils._utils.cds import CASAVisSet
+    from xradio.vis._vis_utils.zarr import write_vis
+    import xarray
+
+    cds = CASAVisSet({}, {(0, 0, "intent#subintent"): xarray.Dataset()}, "empty vis set")
+    outname = "test_vis_empty.zarr"
+    with pytest.raises(KeyError, match="other"):
+        clear_output(outname)
+        write_vis(cds, outname)
+
+
+def test_zarr_write_exists():
+    from xradio.vis._vis_utils.zarr import write_vis
+
+    with tempfile.TemporaryDirectory() as outname:
+        with pytest.raises(ValueError, match="already exists"):
+            res = write_vis({}, outname)
+
+
+def test_zarr_write_ms_minimal(cds_minimal_required):
+    from xradio.vis import read_vis
+    from xradio.vis._vis_utils.zarr import write_vis
+    import copy
+
+    outname = "test_vis_min_write.zarr"
+    clear_output(outname)
+    cds = copy.deepcopy(cds_minimal_required)
+    write_vis(cds, outname)
+
+    from xradio.vis._vis_utils.zarr import is_zarr_vis, read_vis
+    res = is_zarr_vis(outname)
+    assert res
+    # TODO: move into a fixture/similar
+    # @pytest.mark.depends(on=["test_zarr_write_ms_minimal"])
+    cds = read_vis("test_vis_min_write.zarr")
+    
+    
+def test_zarr_write_vis_attrs():
+    """ write to zarr (TODO: revisit) """
+    from xradio.vis._vis_utils._utils.cds import CASAVisSet
+    from xradio.vis._vis_utils.zarr import write_vis
+    import xarray
+
+    empty_part = xarray.Dataset(
+        attrs={"other": {"msv2": {"ctds_attrs": {"column_descriptions": {}}}}}
+    )
+    cds = CASAVisSet({}, {(0, 0, "intent"): empty_part}, "empty vis set")
+    outname = "test_vis_empty.zarr"
+    with pytest.raises(KeyError, match="UVW"):
+        clear_output(outname)
+        write_vis(cds, outname)

--- a/tests/unit/vis/conftest.py
+++ b/tests/unit/vis/conftest.py
@@ -1,0 +1,271 @@
+import pytest
+
+from collections import namedtuple
+import shutil
+
+import xarray as xr
+
+from tests.unit.vis.ms_test_utils.gen_test_ms import gen_test_ms, make_ms_empty
+
+
+# Ensure pytest assert introspection in vis data checker
+pytest.register_assert_rewrite("xradio.vis._vis_utils._utils.cds_checks")
+# If we included a check module inside tests/unit/vis:
+# pytest.register_assert_rewrite("tests.unit.vis.xds_schema_checker")
+# from tests.unit.vis.xds_schema_checker import ...
+
+"""
+A tuple with an MS filename (as str) and a description of its expected structure and contents (as a dict).
+"""
+MSWithSpec = namedtuple("MSWithSpec", "fname descr")
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "uses_download: marks tests that use the function to download test MSs (require medium-size downloads and "
+        "tend to be slower than others)",
+    )
+
+
+@pytest.fixture(scope="session")
+def essential_subtables():
+    """
+    The set of MS subtables (loaded as sub-xdss) without which we cannot read
+    an MS.
+    """
+    return {"antenna", "spectral_window", "polarization"}
+
+
+@pytest.fixture(scope="session")
+def ms_empty_required():
+    """
+    An MS that has all the required tables/columns definitions and is empty
+    (0 rows)
+
+    """
+    name = "test_ms_empty_def_required.ms"
+    make_ms_empty(name)
+    yield MSWithSpec(name, {})
+    shutil.rmtree(name)
+
+
+@pytest.fixture
+def ms_empty_complete(scope="session"):
+    """
+    An MS that has the complete tables/columns definitions and is empty
+    (0 rows)
+
+    """
+    name = "test_ms_empty_def_complete.ms"
+    make_ms_empty(name)
+    yield MSWithSpec(name, {})
+    shutil.rmtree(name)
+
+
+@pytest.fixture(scope="session")
+def ms_minimal_required():
+    name = "test_ms_minimal_required.ms"
+    spec = gen_test_ms(name, required_only=True)
+    yield MSWithSpec(name, spec)
+    shutil.rmtree(name)
+
+
+@pytest.fixture(scope="session")
+def ms_minimal_dims1_required():
+    """
+    An MS populated minimally, with size one for several relevant dimensions:
+    observation, field, scan, spw, etc.
+    """
+    name = "test_ms_minimal_dims1_required.ms"
+    spec = gen_test_ms(name)
+    yield MSWithSpec(name, spec)
+    shutil.rmtree(name)
+
+
+@pytest.fixture(scope="session")
+def ms_tab_nonexistent():
+    name = "test_nonexistent_table_from_test_table_exists.foo.bar.tab"
+    yield MSWithSpec(name, {})
+
+
+@pytest.fixture(scope="session")
+def ms_minimal_for_writes():
+    """MS to be used to write subtables inside"""
+    name = "test_ms_minimal_required_for_writes.ms"
+    spec = gen_test_ms(name, required_only=True)
+    yield MSWithSpec(name, spec)
+    shutil.rmtree(name)
+
+
+@pytest.fixture(scope="session")
+def vis_zarr_empty():
+    """
+    An empty zarr dataset
+    """
+    name = "test_vis_zarr_empty.zarr"
+    xds = xr.Dataset()
+    xds.to_zarr(name)
+    yield name
+    shutil.rmtree(name)
+
+
+@pytest.fixture(scope="session")
+def cds_minimal_required(ms_minimal_required):
+    """ a simple cds data structure read from an MS (also a fixture defined here) """
+    from xradio.vis import read_vis
+
+    cds = read_vis(ms_minimal_required.fname)
+    # Crude fix for unsupported attrs => update/extend attrs dict filters
+    for key, part in cds.partitions.items():
+        # shape attributes which take ndarray type values, added through python-casacore
+        # , "UVW"]: (but UVW was expected, from CASA tests MSs)
+        for col in ["DATA", "CORRECTED_DATA", "MODEL_DATA"]:
+            if (
+                col in part.attrs["other"]["msv2"]["ctds_attrs"]["column_descriptions"]
+                and "shape"
+                in part.attrs["other"]["msv2"]["ctds_attrs"]["column_descriptions"][col]
+            ):
+                part.attrs["other"]["msv2"]["ctds_attrs"]["column_descriptions"][
+                    col
+                ].pop("shape")
+
+    yield cds
+
+
+@pytest.fixture(scope="session")
+def ddi_xds_min(ms_minimal_required):
+    """A DATA_DESCRIPTION/DDI xds, loaded from the minimal MS"""
+    from xradio.vis._vis_utils._ms._tables.read import read_generic_table
+
+    # not available:
+    # subt = cds_minimal_required.metainfo["ddi"]
+
+    subt = read_generic_table(ms_minimal_required.fname, "DATA_DESCRIPTION")
+    return subt
+
+
+@pytest.fixture(scope="session")
+def spw_xds_min(cds_minimal_required):  # ms_minimal_required):
+    """An SPW xds, loaded from the minimal MS/SPECTRAL_WINDOW subtable"""
+
+    subt = cds_minimal_required.metainfo["spectral_window"]
+    # Or alternatively, from ms_minimal_required read subtable
+    # subt = read_generic_table(ms_minimal_required.fname, "SPECTRAL_WINDOW")
+    return subt
+
+
+@pytest.fixture(scope="session")
+def pol_xds_min(cds_minimal_required):
+    """A pol xds, loaded from the minimal MS/POLAIZATION subtable"""
+
+    subt = cds_minimal_required.metainfo["polarization"]
+    # Or alternatively, from ms_minimal_required read subtable
+    # subt = read_generic_table(ms_minimal_required.fname, "POLARIZATION")
+    return subt
+
+
+@pytest.fixture(scope="session")
+def ant_xds_min(cds_minimal_required):
+    """An antenna xds, loaded from the minimal MS/ANTENNA subtable"""
+
+    subt = cds_minimal_required.metainfo["antenna"]
+    # Or alternatively, from ms_minimal_required read subtable
+    # subt = read_generic_table(ms_minimal_required.fname, "ANTENNA")
+    return subt
+
+
+@pytest.fixture(scope="session")
+def field_xds_min(cds_minimal_required):
+    """A field xds, loaded from the minimal MS/FIELD subtable"""
+
+    subt = cds_minimal_required.metainfo["field"]
+    # Or alternatively, from ms_minimal_required read subtable
+    # subt = read_generic_table(ms_minimal_required.fname, "FIELD")
+    return subt
+
+
+@pytest.fixture(scope="session")
+def feed_xds_min(cds_minimal_required):
+    """A feed xds, loaded from the minimal MS/FEED subtable"""
+
+    subt = cds_minimal_required.metainfo["feed"]
+    # Or alternatively, from ms_minimal_required read subtable
+    # subt = read_generic_table(ms_minimal_required.fname, "FEED")
+    return subt
+
+
+@pytest.fixture(scope="session")
+def observation_xds_min(cds_minimal_required):
+    """An observation xds, loaded from the minimal MS/OBSERVATION subtable"""
+
+    subt = cds_minimal_required.metainfo["observation"]
+    # Or alternatively, from ms_minimal_required read subtable
+    # subt = read_generic_table(ms_minimal_required.fname, "OBSERVATION")
+    return subt
+
+
+@pytest.fixture(scope="session")
+def source_xds_min(cds_minimal_required):
+    """A source xds, loaded from the minimal MS/SOURCE subtable"""
+
+    subt = cds_minimal_required.metainfo["source"]
+    # Or alternatively, from ms_minimal_required read subtable
+    # subt = read_generic_table(ms_minimal_required.fname, "SOURCE")
+    return subt
+
+
+@pytest.fixture(scope="session")
+def main_xds_min(ms_minimal_required):
+    """A main xds (one partition, when partitioning by intent"""
+    from xradio.vis._vis_utils.ms import read_ms
+
+    cds = read_ms(ms_minimal_required.fname, partition_scheme="intent")
+    part_key = (0, 0, "scan_intent#subscan_intent")
+    part = cds.partitions[part_key]
+    # shape attributes which take ndarray type values, added through
+    # python-casacore, "fix" for the experimental write MS
+    # , "UVW"]: (but UVW was expected, from CASA tests MSs)
+    for col in ["DATA", "CORRECTED_DATA", "MODEL_DATA"]:
+        if (
+            col in part.attrs["other"]["msv2"]["ctds_attrs"]["column_descriptions"]
+            and "shape"
+            in part.attrs["other"]["msv2"]["ctds_attrs"]["column_descriptions"][col]
+        ):
+            part.attrs["other"]["msv2"]["ctds_attrs"]["column_descriptions"][col].pop(
+                "shape"
+            )
+
+    yield part
+
+
+# TODO: consider @pytest.mark.ms_custom_spec({...})
+@pytest.fixture(scope="session")
+def ms_custom(spec):
+    name = "test_ms_custom.ms"  # + rnd
+    gen_test_ms(name, spec)
+    yield name
+    shutil.rmtree(name)
+
+
+@pytest.fixture(scope="session")
+def ms_alma_antennae_north_split():
+    """
+    An MS that is downloaded (one of the smallest), with multiple fields (3)
+    + with SOURCE and STATE populated
+    """
+    from graphviper.utils.data import download
+
+    name = "Antennae_North.cal.lsrk.split.ms"
+    # name = "small_meerkat.ms"
+    download(file=name)
+    # TODO: extend with more attrs
+    descr = {"nchans": 8, "npols": 2}
+    yield MSWithSpec(name, descr)
+
+
+@pytest.fixture(scope="session")
+def ms_as_zarr_min():
+    """An MS loaded and then saved to zarr format"""
+    name = "xds_saved_as_zarr_bogus_for_now.zarr"
+    yield name

--- a/tests/unit/vis/ms_test_utils/cds_checks.py
+++ b/tests/unit/vis/ms_test_utils/cds_checks.py
@@ -1,0 +1,229 @@
+from typing import Union
+from xradio.vis._vis_utils._utils.cds import CASAVisSet
+
+
+def check_cds(
+    vis: CASAVisSet,
+    partition_scheme: str = "intent",
+    descr: dict = None,
+    subtables: Union[list, None] = None,
+    chunks: bool = False,
+):
+    """
+    Loose consistency check on a cngi-io/xradio cds visibilities dataset.
+    This does not claim to be complete (at all) but should catch all obvious
+    issue and most common issues. To be replaced/superseded by a proper
+    MSv4 schema validator + additional checks.
+
+    The check functions called from here do not return anything, they simply
+    assert (which is much nicer if the asserts are rewritten using
+    pytest.register_assert_rewrite).
+
+    Parameters
+    ----------
+    vis : CASAVisSet :
+
+    partition_scheme : str (Default value = "intent")
+        the scheme used to load the MS. Relevant for metainfo and partition
+        keys.
+    descr : dict (Default value = None)
+        description of the visibilities dataset (used in gen_test_ms to
+        produce it or otherwise describing some of the dataset properties)
+    subtables : Union[list, None] (Default value = None)
+        subtables that have been loaded and are expected to pass checks.
+        If left to its default (None) the check functions will check
+        a baseline list of subtables (growing but not exhaustive)
+    chunks : bool (Default value = False)
+        whether data blocks/chunks have been loaded
+
+    Returns
+    -------
+
+    """
+
+    assert vis is not None
+    check_vis_metainfo(vis, partition_scheme, descr, subtables)
+    check_vis_partitions(vis, partition_scheme, descr, chunks)
+
+
+def check_vis_metainfo(
+    vis: CASAVisSet,
+    partition_scheme: str,
+    descr: str,
+    subtables: Union[list, None] = None,
+):
+    """
+
+    Parameters
+    ----------
+    vis : CASAVisSet
+
+    partition_scheme : str
+
+    descr : str
+
+    subtables : Union[list, None] (Default value = None)
+
+    Returns
+    -------
+
+    """
+    if subtables == None:
+        subtables = [
+            "antenna",
+            "spectral_window",
+            "polarization",
+            "field",
+            "source",
+            "state",
+        ]
+
+    assert not subtables or all(subt in vis.metainfo for subt in subtables)
+
+    # TODO: dict subt_name => check functions
+    if "antenna" in subtables:
+        check_subxds_antenna(vis.metainfo["antenna"])
+    if "spectral_window" in subtables:
+        check_subxds_spectral_window(vis.metainfo["spectral_window"])
+    # check_subxds_polarization(vis.metainfo["spectral_window"]
+    if "field" in subtables:
+        check_subxds_field(vis.metainfo["field"])
+    # check_subxds_source(vis.metainfo["source"]
+    # check_subxds_state(vis.metainfo["state"]
+
+
+def check_subxds_antenna(xds):
+    # TODO: use dicts from code itself
+    assert "antenna_id" in xds.dims
+    res = [var in xds.data_vars for var in ["position", "offset", "station"]]
+    assert xds.attrs
+
+
+def check_subxds_spectral_window(xds):
+    # TODO: use dicts from code itself
+    assert "spectral_window_id" in xds.dims
+    res = [var in xds.data_vars for var in ["ref_frequency", "effective_bw"]]
+    assert xds.attrs
+
+
+def check_subxds_field(xds):
+    # TODO: use dicts from code itself
+    assert "field_id" in xds.dims
+    res = [var in xds.data_vars for var in ["name", "code", "time", "source_id"]]
+    assert xds.attrs
+
+
+def check_vis_partitions(vis, partition_scheme, descr, chunks):
+    expected_part_key = (0, 0, "scan_intent#subscan_intent")
+
+    # assert len(vis.partitions) == 1
+    # assert expected_part_key in vis.partitions
+
+    # part = vis.partitions[expected_part_key]
+    # check_partition_data(part)
+    # check_partition_metainfo(part)
+
+    # These two paths should be better merged...
+    if not chunks:
+        check_vis_partitions_read(vis, partition_scheme, descr, chunks)
+    else:
+        check_vis_partitions_load(vis, partition_scheme, descr, chunks)
+
+
+def check_vis_partitions_read(vis, partition_scheme, descr, chunks):
+    for key, part in vis.partitions.items():
+        check_partition_data(part, descr)
+        check_partition_metainfo(part, partition_scheme, descr, chunks)
+
+
+def check_vis_partitions_load(vis, partition_scheme, descr, chunks):
+    for key, val in vis.partitions.items():
+        for ckey, part in val.items():
+            check_partition_data(part, descr)
+            check_partition_metainfo(part, partition_scheme, descr, chunks)
+
+
+def check_partition_data(part, descr):
+
+    expected_coords_with_dim = {"time", "baseline", "pol", "freq", "antenna_id"}
+    check_partition_coords(part.coords, expected_coords_with_dim)
+
+    expected_dims_wo_coords = {"uvw_coords"}
+
+    # TODO: dimensions without coordiates: uvw_coords + (poly_id, ra/dec) if
+    # in descr.
+    check_partition_dims(part.sizes, expected_dims_wo_coords)
+
+    # TODO: assert len(part.data_vars) >/== 16*
+    check_partition_data_vars(part.data_vars)
+
+
+def check_partition_coords(coords, expected_coords_with_dim):
+    keys = coords.keys()
+    assert keys == expected_coords_with_dim
+
+    # assert all([coo in coords for coo in expected_coords])
+    time = "time"
+    assert all([att in coords[time].attrs for att in ["units", "measure"]])
+    assert all(
+        [matt in coords[time].attrs["measure"] for matt in ["type", "ref_frame"]]
+    )
+    assert coords[time].attrs["units"] == "s"
+    assert coords[time].attrs["measure"]["type"] == "epoch"
+    assert coords[time].attrs["measure"]["ref_frame"] == "UTC"
+
+    freq = "freq"
+    assert all([att in coords[freq].attrs for att in ["units", "measure"]])
+    assert all(
+        [matt in coords[freq].attrs["measure"] for matt in ["type", "ref_frame"]]
+    )
+    assert coords[freq].attrs["units"] == "Hz"
+    assert coords[freq].attrs["measure"]["type"] == "frequency"
+    # incomplete set
+    assert coords[freq].attrs["measure"]["ref_frame"] in {"TOPO", "LSRK", "REST"}
+
+
+def check_partition_dims(dims, expected_dims_wo_coords):
+    assert all([dim in dims.keys() for dim in expected_dims_wo_coords])
+
+
+def check_partition_data_vars(data_vars):
+    exp_data_vars = {
+        "uvw",
+        "flag",
+        "array_id",
+        "exposure",
+        "feed1_id",
+        "feed2_id",
+        "field_id",
+        "interval",
+        "observation_id",
+        "processor_id",
+        "scan_number",
+        "state_id",
+        "time_centroid",
+        "vis",
+        "baseline_ant1_id",
+        "baseline_ant2_id",
+    }  # vis_correcred
+    assert exp_data_vars <= data_vars.keys()
+
+
+def check_partition_metainfo(part, partition_scheme, descr, chunks):
+    check_part_attrs(part.attrs, partition_scheme, chunks)
+    exp_ids = {'array_id': [0], 'observation_id': [0], 'pol_setup_id': 0,
+               'processor_id': [0], "spw_id": 0}
+    # For the values we'd need a properly populated 'descr'
+    assert part.attrs["partition_ids"].keys() == exp_ids.keys()
+
+
+def check_part_attrs(attrs, partition_scheme, chunks):
+    exp_attrs = {"partition_ids", "vis_groups"}
+    if not chunks:
+        exp_attrs.add("other")
+
+    # only present when intent is not considered for partitioning
+    if not chunks and partition_scheme == "intent":
+        exp_attrs.add("scan_subscan_intents")
+
+    assert exp_attrs == attrs.keys()

--- a/tests/unit/vis/ms_test_utils/gen_test_ms.py
+++ b/tests/unit/vis/ms_test_utils/gen_test_ms.py
@@ -1,0 +1,961 @@
+"""
+Generates MeasurementSets. The motivation is to generate on-the-fly MSs in
+unit tests (normally as pytest fixtures).
+It has been growing driven by iterative increase of coverage in unit tests.
+"""
+
+from contextlib import contextmanager
+import datetime
+import itertools
+from pathlib import Path
+from typing import Generator
+
+import numpy as np
+
+import casacore.tables as tables
+from casacore.tables import default_ms, default_ms_subtable
+from casacore.tables.tableutil import makedminfo, maketabdesc
+from casacore.tables.msutil import complete_ms_desc, makearrcoldesc, required_ms_desc
+
+
+# 2 observations, 2 fields, 2 states
+# 2 SPWs, 4 polarizations
+default_ms_descr = {
+    "nchans": 32,
+    "npols": 2,
+    "data_cols": ["DATA"],  # ['CORRECTED_DATA'],
+    # DATA / CORRECTED, etc.
+    # subtables needed to test xds structure
+    "SPECTRAL_WINDOW": {"0": 0, "1": 1},
+    "POLARIZATION": {"0": 0, "1": 1},  # "2": 2, "3": 3},
+    "ANTENNA": {"0": 0, "1": 1, "2": 2, "3": 3, "4": 4},
+    # subtables neded to test partitioning
+    "FIELD": {"0": 0, "1": 1},
+    "EPHEMERIDES": {0: 0},
+    "SCAN": {
+        "1": {
+            "0": {"intent": "CAL_ATMOSPHERE#ON_SOURCE"},
+            "1": {"intent": "CAL_ATMOSPHERE#OFF_SOURCE"},
+        },
+        "2": {
+            "0": {"intent": "OBSERVE_TARGET#ON_SOURCE"},
+            "1": {"intent": "OBSERVE_TARGET#ON_SOURCE"},
+            "2": {"intent": "OBSERVE_TARGET#ON_SOURCE"},
+            "3": {"intent": "OBSERVE_TARGET#ON_SOURCE"},
+        },
+        "3": {
+            "0": {"intent": "CALIBRATE_DELAY#ON_SOURCE,CALIBRATE_PHASE#ON_SOURCE"},
+            "1": {"intent": "CALIBRATE_DELAY#ON_SOURCE,CALIBRATE_PHASE#ON_SOURCE"},
+            "2": {"intent": "CALIBRATE_DELAY#ON_SOURCE,CALIBRATE_PHASE#ON_SOURCE"},
+        },
+    },
+    # CALIBRATE_ATMOSPHERE#OFF_SOURCE,CALIBRATE_ATMOSPHERE#ON_SOURCE,CALIBRATE_WVR#OFF_SOURCE,CALIBRATE_WVR#ON_SOURCE
+    "STATE": {
+        "0": {"id": 0, "intent": "CAL_ATMOSPHERE#ON_SOURCE"},
+        "1": {"id": 1, "intent": "CAL_ATMOSPHERE#OFF_SOURCE"},
+    },
+    "OBSERVATION": {"0": 0, "1": 1},
+    # Mandatory as per MSv2 but not essential to be able to build xdss
+    "FEED": {"0": 0},
+    "POINTING": {},
+    "PROCESSOR": {"0": 0, "1": 1},
+    "SOURCE": {"0": 0, "1": 1},
+    # Auto-generated without parameters for now:
+    # 'FLAG_CMD': {},
+    # 'HISTORY': {},
+}
+
+
+def gen_test_ms(
+    msname: str, descr: dict = None, opt_tables: bool = True, required_only: bool = True
+):
+    """
+    Generates an MS for testing purposes, including main table and
+    subtables, either only the required ones or all. Follows the MSv2
+    definitions. The aim is to produce MSs with the minimal structure and
+    set of rows to exercise xradio functions.
+
+    - To be able to effectively start testing some functions, these are
+    required: MAIN, DATA_DESCRIPTION, SPECTRAL_WINDOW, POLARIZATION, ANTENNA
+    - To be able to start testing partitioning: FIELD, STATE
+    - Furhter partitioning testing: observation, processor, feed?
+
+    - The optional tables SYSCAL, WEATHER are generated with very (too)
+      simple contents
+
+    Parameters
+    ----------
+    msname : str
+        name of MS on disk
+    descr : dict (Default value = None)
+        MS description, including description of scans, fields,
+        intents, etc. By default (empty dict) will create an MS with minimal
+        structure (one observation, one array, one scan, one field, etc.)
+    opt_tables : bool (Default value = True)
+        whether to produce optional (sub)tables, such as SOURCE, WEATHER
+    required_only : bool (Default value = True)
+        whether to use the complete or required columns spec
+
+    Returns
+    -------
+
+    """
+    if not descr:
+        descr = default_ms_descr
+
+    # Definitely needed: main table + following subtables: DATA_DESCRIPTPION
+    #  + SPECTRAL_WINDOW + POLARIZATION
+    #  + ANTENNNA (just for the names)
+    # All these are required to create the xdss (they define data and dims)
+    outdescr = gen_main_table(msname, descr, required_only)
+    gen_subt_ddi(msname, descr["SPECTRAL_WINDOW"], descr["POLARIZATION"])
+    gen_subt_spw(msname, descr["SPECTRAL_WINDOW"])
+    gen_subt_antenna(msname, descr["ANTENNA"])
+    gen_subt_pol_setup(msname, descr["npols"], descr["POLARIZATION"])
+
+    # Also needed for partitioning: FIELD, STATE
+    gen_subt_field(msname, descr["FIELD"])
+    gen_subt_state(msname, descr["STATE"])
+
+    # Required by MSv2/v3 but not strictly required to load and partition:
+
+    # BEAM (only MSv3)
+
+    # FEED
+    gen_subt_feed(msname, descr["FEED"], descr["ANTENNA"], descr["SPECTRAL_WINDOW"])
+
+    # HISTORY
+    gen_subt_history(msname, descr["OBSERVATION"])
+
+    # OBSERVATION
+    gen_subt_observation(msname, descr["OBSERVATION"])
+
+    # POINTING: TODO
+    gen_subt_pointing(msname)
+
+    # PROCESSOR
+    gen_subt_processor(msname, descr["PROCESSOR"])
+
+    if opt_tables:
+        # DOPPLER: no examples seen in test MSs
+
+        # EPHEMERIDES (only defined in Msv3, never seen in practice)
+
+        # FLAG_CMD (made optional in MSv3, required in MSv2)
+        gen_subt_flag_cmd(msname)
+
+        # FREQ_OFFSET: no examples seen in test MSs
+
+        # INTERFEROMETER_MODEL (only MSv3)
+
+        # PHASED_ARRAY (only MSv3)
+
+        # QUALITY_FREQUENCY_STATISTIC (only MSv3: listend but never defined)
+
+        # QUALITY_BASELINE_STATISTIC (only MSv3: listend but never defined)
+
+        # QUALITY_TIME_STATISTIC (only MSv3: listend but never defined)
+
+        # SOURCE
+        gen_subt_source(msname, descr["SOURCE"])
+
+        # SCAN (Only MSv3)
+
+        # SYSCAL
+        gen_subt_syscal(msname)
+
+        # WEATHER
+        gen_subt_weather(msname)
+
+        # ASDM_* subtables. One simple example
+        gen_subt_asdm_receiver(msname)
+
+    return outdescr
+
+
+def make_ms_empty(name: str, descr: dict = None, complete: bool = False):
+    """
+    OLD simple function. makes empty (0 rows) MSs
+
+    Parameters
+    ----------
+    name : str
+
+    descr : dict (Default value = None)
+
+    complete : bool (Default value = False)
+
+    Returns
+    -------
+
+    """
+    if complete:
+        tabdesc = complete_ms_desc("MAIN")
+    else:
+        tabdesc = required_ms_desc("MAIN")
+
+    datacoldesc = tables.makearrcoldesc(
+        "DATA",
+        0.1 + 0.1j,
+        valuetype="complex",
+        ndim=2,
+        datamanagertype="TiledShapeStMan",
+        datamanagergroup="TiledData",
+        comment="The data column",
+    )
+    del datacoldesc["desc"]["shape"]
+    tabdesc.update(tables.maketabdesc(datacoldesc))
+
+    weightspeccoldesc = tables.makearrcoldesc(
+        "WEIGHT_SPECTRUM",
+        1.0,
+        valuetype="float",
+        ndim=2,
+        datamanagertype="TiledShapeStMan",
+        datamanagergroup="TiledWgtSpectrum",
+        comment="Weight for each data point",
+    )
+    del weightspeccoldesc["desc"]["shape"]
+    tabdesc.update(tables.maketabdesc(weightspeccoldesc))
+
+    vis = tables.default_ms(name, tabdesc=tabdesc, dminfo=makedminfo(tabdesc))
+    assert vis.nrows() == 0
+
+
+def gen_main_table(mspath: str, descr: dict, required_only: bool = True):
+    """
+    Create main MSv2 table.
+    Relies on the required/complete_ms_desc descriptions of columns
+
+    Simplifications/assumptions:
+    - All polarization setups have the same number of correlations/
+    - All scans have the same SPWs (all SPWs)
+    - Multiple observation: just repeat the same structure (same scans,
+      fields, etc.)
+    - Can generate multiple *_DATA columns but they all have the same data
+      pattern
+
+    :return: outdescr
+
+    Parameters
+    ----------
+    mspath: str :
+
+    descr: dict :
+
+    required_only: bool :
+         (Default value = True)
+
+    Returns
+    -------
+
+    """
+
+    outdescr = descr.copy()
+
+    if descr == {}:
+        nchans = 16
+        npols = 2
+    else:
+        nchans = descr["nchans"]
+        npols = descr["npols"]
+
+    if required_only:
+        ms_desc = required_ms_desc("MAIN")
+    else:
+        ms_desc = complete_ms_desc("MAIN")
+
+    ms_desc["UVW"].update(
+        options=0,
+        shape=[3],
+        ndim=1,
+        dataManagerGroup="UVWGroup",
+        dataManagerType="TiledColumnStMan",
+    )
+    dmgroups_spec = {"UVW": {"DEFAULTTILESHAPE": [3, nchans]}}
+
+    # data columns. TODO: move to function - make_data_cols_descr
+    for data_col_name in descr["data_cols"]:
+        data_col_desc = makearrcoldesc(
+            data_col_name,
+            0.0,
+            options=4,
+            valuetype="complex",
+            # Beware of the additional column description entry - not present in casatestdata
+            shape=[nchans, npols],
+            ndim=2,
+            datamanagertype="TiledColumnStMan",
+            datamanagergroup="DataGroup",
+            comment="added by gen_test_ms",
+        )
+        ms_desc.update(maketabdesc(data_col_desc))
+
+        dmgroups_spec.update(
+            {"DataColsGroup": {"DEFAULTTILESHAPE": [nchans, npols, 32]}}
+        )
+        ms_data_man_info = makedminfo(ms_desc, dmgroups_spec)
+
+    if not "STATE" in descr:
+        vis = tables.default_ms(name, tabdesc=tabdesc, dminfo=makedminfo(tabdesc))
+        assert vis.nrows() == 0
+        return
+    # else:
+    #    populate (TODO)
+
+    # Key columns (that define data rows):
+    # - TIME: given in descr
+    # - ANTENNA1, ANTENNA2: given in descr
+    # - DATA_DESC_ID, PROCESSOR_ID: given in descr
+    # - FEED1, FEED2, assumed 0
+    # - Not considered: ANTENNA3, FEED3, PHASE_ID, TIME_EXTRA_PREC
+
+    with default_ms(mspath, ms_desc, ms_data_man_info) as msv2:
+        desc = msv2.getcoldesc("UVW")
+        assert desc["dataManagerType"] == "TiledColumnStMan"
+        dminfo = msv2.getdminfo("UVW")
+        assert dminfo["NAME"] == "UVWGroup"
+
+        # Figure out amount of rows and related IDs
+        nrows = 300
+        dd_pairs = list(
+            itertools.product(
+                list(descr["SPECTRAL_WINDOW"].values()), descr["POLARIZATION"].values()
+            )
+        )
+        nddis = len(dd_pairs)
+        outdescr["nddis"] = nddis
+        dd_ids = np.arange(nddis)
+        nrows *= nddis
+        # problem: TIME - SPW
+
+        msv2.addrows(nrows)
+        # trasnposing so that indices increase with channel number, not pol
+        vis_val = np.arange(nchans * npols).reshape(
+            (npols, nchans)
+        ).transpose() * np.complex64(1 - 1j)
+        # vis_val *= np.arange(
+        # msv2.putcell("CORRECTED_DATA", 0, vis_val)
+        for data_col in descr["data_cols"]:
+            msv2.putcol(data_col, np.broadcast_to(vis_val, (nrows, nchans, npols)))
+
+        # === Key attributes ===
+        # Make Ids
+
+        # TIME
+        CASACORE_TO_DATETIME_CORRECTION = 3_506_716_800.0
+        start = (
+            datetime.datetime(
+                2023, 5, 1, 1, 1, tzinfo=datetime.timezone.utc
+            ).timestamp()
+            + CASACORE_TO_DATETIME_CORRECTION
+        )
+        time_col = np.arange(nrows) + start
+        msv2.putcol("TIME", time_col)
+
+        # (TIME_EXTRA_PREC): nothing for now
+
+        nants = len(descr["ANTENNA"])
+        # ANTENNA1, ANTENNA2
+        # baselines = list(itertools.product(ants, ants))
+        # combinations without repetitions: baselines as list of tuples
+        ants = np.arange(nants)
+        baselines = list(itertools.combinations(ants, 2))
+        ant1_ant2 = list(zip(*baselines))
+
+        # TODO: needs fixes for rounding
+        reps = np.tile(ant1_ant2[0], int(nrows / len(baselines)))
+        msv2.putcol("ANTENNA1", np.tile(ant1_ant2[0], int(nrows / len(baselines))))
+        msv2.putcol("ANTENNA2", np.tile(ant1_ant2[1], int(nrows / len(baselines))))
+
+        # (ANTENNA3): nothing for now
+
+        msv2.putcol("FEED1", np.broadcast_to(0, (nrows)))
+
+        msv2.putcol("FEED2", np.broadcast_to(0, (nrows)))
+
+        # (FEED3): nothing for now
+
+        # DATA_DESC_ID
+        # msv2.putcol("DATA_DESC_ID", np.broadcast_to(0, (nrows)))
+        ddi_col = np.repeat(dd_ids, nrows / nddis)
+        # print(f" This is nddis: {nddis} len dd_id: {len(dd_ids)}, with nrows: {nrows}")
+        msv2.putcol("DATA_DESC_ID", np.broadcast_to(ddi_col, (nrows)))
+
+        msv2.putcol("PROCESSOR_ID", np.broadcast_to(0, (nrows)))
+
+        msv2.putcol("FIELD_ID", np.broadcast_to(0, (nrows)))
+
+        # PHASE_ID: nothing for now
+
+        # === Non-key attributes ===
+
+        # The ones that are IDs
+        msv2.putcol("OBSERVATION_ID", np.broadcast_to(0, (nrows)))
+
+        msv2.putcol("ARRAY_ID", np.broadcast_to(0, (nrows)))
+
+        msv2.putcol("SCAN_NUMBER", np.broadcast_to(1, (nrows)))
+
+        # STATE_ID: if no states/intents => all STATE_ID = -1
+        no_state = False
+        if no_state:
+            msv2.putcol("STATE_ID", np.broadcast_to(-1, (nrows)))
+        else:
+            msv2.putcol("STATE_ID", np.broadcast_to(0, (nrows)))
+
+        # Make other scalar / inc columns
+
+        interval = 1.0
+        msv2.putcol("INTERVAL", np.broadcast_to(interval, (nrows)))
+
+        exposure = 0.9 * interval
+        msv2.putcol("EXPOSURE", np.broadcast_to(exposure, (nrows)))
+
+        # TIME_CENTROID
+        msv2.putcol("TIME_CENTROID", time_col)
+
+        # (PULSAR_BIN)
+
+        # (PULSAR_GATE_ID)
+
+        # (BASELINE_REF)
+
+        # UVW
+        msv2.putcol("UVW", np.broadcast_to([1.0, 0.5, 1.5], (nrows, 3)))
+
+        # (UVW2)
+
+        # (DATA)
+
+        # (FLOAT_DATA)
+
+        # (VIDEO_POINT)
+
+        # (LAG_DATA)
+
+        # SIGMA
+        msv2.putcol("SIGMA", np.broadcast_to(1.0, (nrows, npols)))
+
+        # (SIGMA_SPECTRUM)
+
+        # WEIGHT
+        # msv2.putcol("WEIGHT", np.broadcast_to(1.0, (nrows, npols)))
+
+        # (WEIGHT_SPECTRUM)
+
+        msv2.putcol("FLAG", np.broadcast_to(False, (nrows, nchans, npols)))
+
+        # FLAG_CATEGORY: leave empty
+
+        msv2.putcol("FLAG_ROW", np.broadcast_to(False, (nrows)))
+
+    # with tables.table(mspath) as main:
+    #     print(f"** after default_ms: {main.getkeywords()}")
+    return outdescr
+
+
+def gen_subt_ddi(mspath: str, spws_descr: dict, pol_setup_descr: dict):
+    """
+    Populates DATA_DESCRIPTION
+    Q: spws_descr with IDs in keys? IDs in MSv2 are implicit 0...n-1
+    """
+    import itertools
+
+    # TODO generate spw-pol
+    with tables.table(
+        mspath + "::DATA_DESCRIPTION", ack=False, readonly=False
+    ) as ddi_tbl:
+        nrows = len(spws_descr) * len(pol_setup_descr)
+        ddi_tbl.addrows(nrows)
+
+        ddis = list(
+            itertools.product(list(spws_descr.values()), pol_setup_descr.values())
+        )
+        spw_ids = list(zip(*ddis))[0]
+        pol_ids = list(zip(*ddis))[1]
+        ddi_tbl.putcol("SPECTRAL_WINDOW_ID", spw_ids)
+        ddi_tbl.putcol("POLARIZATION_ID", pol_ids)
+        ddi_tbl.putcol("FLAG_ROW", np.broadcast_to(False, nrows))
+
+
+def gen_subt_spw(mspath: str, spw_descr: dict):
+    """
+    Populates SPECTRAL_WINDOW
+    """
+
+    nspws = len(spw_descr)
+    with tables.table(
+        mspath + "::SPECTRAL_WINDOW", ack=False, readonly=False
+    ) as spw_tbl:
+        spw_tbl.addrows(nspws)
+        # Not in MSv2
+        # spw_tbl.putcol("SPECTRAL_WINDOW_ID", list(spw_descr.keys()))
+        names = [f"unspecified_test#{idx}" for idx in range(nspws)]
+        spw_tbl.putcol("NAME", names)
+        # spw_tbl.putcol("REF_FREQUENCY", nspws*[0.9e9])
+        # spw_tbl.putcol("TOTAL_BANDWIDTH", nspws*[0.020])
+
+        for spw in range(nspws):
+            # nchan = spw_descr[spw]['NUM_CHAN']
+            # spw_tbl.addrows(1)  # 1
+            nchan = 32
+
+            # spw_tbl.putcell("NAME", spw, "unspecified_test")
+            spw_tbl.putcell("REF_FREQUENCY", spw, 0.9e9)
+
+            spw_tbl.putcol("NUM_CHAN", nchan, startrow=spw, nrow=1)
+            widths = np.full(nchan, 20000.0)
+            spw_tbl.putcell("CHAN_WIDTH", spw, widths)
+            # or alternatively
+            # spw_tbl.putcol("CHAN_WIDTH", np.full((1, nchan), 20000.0), startrow=spw, nrow=1)
+            spw_tbl.putcell("CHAN_FREQ", spw, np.full(nchan, 10e0))
+            spw_tbl.putcell("EFFECTIVE_BW", spw, widths)
+            spw_tbl.putcell("TOTAL_BANDWIDTH", spw, sum(widths))
+            spw_tbl.putcell("RESOLUTION", spw, widths)
+
+
+def gen_subt_pol_setup(mspath: str, npols, pol_setup_descr: dict):
+    """
+    populates POLARIZATION
+    """
+
+    nsetups = len(pol_setup_descr)
+
+    with tables.table(mspath + "::POLARIZATION", ack=False, readonly=False) as pol_tbl:
+        pol_tbl.addrows(npols)
+        # pol_tbl.putcol("POLARIZATION_ID", list(spw_descr.keys()))
+        pol_tbl.putcol("NUM_CORR", nsetups * [npols])
+        pol_tbl.putcol("FLAG_ROW", nsetups * [False])
+        corr_types = [9, 11, 13, 15]
+        pol_tbl.putcol(
+            "CORR_TYPE", np.broadcast_to(corr_types[:npols], (nsetups, npols))
+        )
+        corr_products = [0, 0, 1, 1]
+        pol_tbl.putcol(
+            "CORR_PRODUCT", np.broadcast_to(corr_products[:npols], (nsetups, 2, npols))
+        )
+
+
+def gen_subt_antenna(mspath: str, ant_descr: dict):
+    """
+    create ANTENNA
+    """
+
+    with tables.table(mspath + "::ANTENNA", ack=False, readonly=False) as ant_tbl:
+        nants = len(ant_descr)
+        ant_tbl.addrows(nants)
+        ant_tbl.putcol("NAME", [f"test_antenna_{idx}" for idx in range(nants)])
+        ant_tbl.putcol("STATION", [f"test_station_{idx}" for idx in range(nants)])
+        ant_tbl.putcol("DISH_DIAMETER", nants * [12])
+        ant_tbl.putcol("FLAG_ROW", nants * [False])
+        ant_tbl.putcol("POSITION", np.broadcast_to([0.01, 0.02, 0.03], (nants, 3)))
+        ant_tbl.putcol("POSITION", np.broadcast_to([0.0, 0.0, 0.0], (nants, 3)))
+
+
+# field and state very relevant for partitions/sub-MSv2
+def gen_subt_field(mspath: str, fields_descr: dict, gen_ephem: bool = True):
+    """
+    creates FIELD
+
+    only supports polynomials with 1 coefficient
+    """
+
+    with tables.table(mspath + "::FIELD", ack=False, readonly=False) as fld_tbl:
+        nfields = len(fields_descr)
+        fld_tbl.addrows(nfields)
+        fld_tbl.putcol("NAME", nfields * ["NGC3031"])
+
+        npoly = 0
+        fld_tbl.putcol("NUM_POLY", nfields * [npoly])
+
+        adir = np.deg2rad([30, 45])
+        for dir_col in ["DELAY_DIR", "PHASE_DIR", "REFERENCE_DIR"]:
+            fld_tbl.putcol(dir_col, np.broadcast_to(adir, (nfields, npoly + 1, 2)))
+
+    if gen_ephem:
+        gen_subt_ephem(mspath)
+
+
+def gen_subt_ephem(mspath: str):
+    """
+    Creates a phony ephemerides table under the FIELD subtable.
+    The usual tables... context or 'default_ms_subtable' not working. Needs
+    manual coldesc /not in MSv2/3
+    """
+    # with open_opt_subtable(mspath, "FIELD/EPHEM0_FIELD.tab") as wtbl:
+    ephem0_path = Path(mspath) / "FIELD" / "EPHEM0_FIELDNAME.tab"
+    tabdesc = {
+        "MJD": {
+            "valueType": "double",
+            "dataManagerType": "StandardStMan",
+            "dataManagerGroup": "StandardStMan",
+            "option": 0,
+            "maxlen": 0,
+            "comment": "comment...",
+            "keywords": {
+                "QuantumUnits": ["s"],
+                "MEASINFO": {"type": "epoch", "Ref": "bogus MJD"},
+            },
+        }
+    }
+    with tables.table(
+        str(ephem0_path), tabledesc=tabdesc, nrow=1, readonly=False, ack=False
+    ) as tbl:
+        tbl.putcol("MJD", 50000)
+
+
+def gen_subt_state(mspath: str, states_descr: dict):
+    """
+    populates STATE
+    """
+
+    # intents in OBS_MODE strings
+    with tables.table(mspath + "::STATE", ack=False, readonly=False) as st_tbl:
+        nstates = len(states_descr)
+        st_tbl.addrows(nstates)
+        st_tbl.putcol("SIG", nstates * [True])
+        st_tbl.putcol("REF", nstates * [False])
+        st_tbl.putcol("CAL", nstates * [0.0])
+        st_tbl.putcol("LOAD", nstates * [0.0])
+        # TODO: generate subscan ids for potentially multiple scans
+        st_tbl.putcol("SUB_SCAN", 1 + np.arange(nstates))
+        st_tbl.putcol("OBS_MODE", nstates * ["scan_intent#subscan_intent"])
+        st_tbl.putcol("FLAG_ROW", nstates * [False])
+
+
+# Other - optional subtables
+
+
+@contextmanager
+def open_opt_subtable(
+    mspath: str, tbl_name: str
+) -> Generator[tables.table, None, None]:
+    """
+    Opens an (optional) subtable of an MS. This can open tables not included
+    in the default_ms definition
+
+    Parameters
+    ----------
+    mspath : str
+        path of output MS
+    tbl_name : str
+        name of the subtable (WEATHER, etc.). Requires a known optional MS
+        subtable name that has a known table description.
+
+    Returns
+    -------
+    Generator[tables.table, None, None]
+        context for an optional subtable created as per MSv2 specs
+    """
+    subt_desc = tables.complete_ms_desc(tbl_name)
+    # table = tables.table(mspath + "/" + tbl_name, tabledesc=subt_desc,
+    #                dminfo=makedminfo(subt_desc), ack=False, readonly=False)
+    table = default_ms_subtable(tbl_name, mspath + "/" + tbl_name, subt_desc)
+    try:
+        yield table
+    finally:
+        table.close()
+
+
+def gen_subt_source(mspath: str, src_descr: dict):
+    """
+    Populate SOURCE subtable, with time dependent source info
+    """
+
+    # SOURCE is not included in default_ms
+    # with tables.table(mspath + "::SOURCE", ack=False, readonly=False) as src_tbl:
+    with open_opt_subtable(mspath, "SOURCE") as src_tbl:
+        nsrcs = len(src_descr)
+        src_tbl.addrows(nsrcs)
+        src_tbl.putcol("SOURCE_ID", list(src_descr.values()))
+        src_tbl.putcol("TIME", np.broadcast_to(0, (nsrcs)))
+        src_tbl.putcol("INTERVAL", np.broadcast_to(0, (nsrcs)))
+        src_tbl.putcol("SPECTRAL_WINDOW_ID", np.broadcast_to(0, (nsrcs)))
+
+        src_tbl.putcol("NAME", np.broadcast_to("test_source_name", (nsrcs)))
+        src_tbl.putcol("CALIBRATION_GROUP", np.broadcast_to(0, (nsrcs)))
+        src_tbl.putcol("CODE", np.broadcast_to("test_source", (nsrcs)))
+        adir = np.deg2rad([29, 34])
+        src_tbl.putcol("DIRECTION", np.broadcast_to(adir, (nsrcs, 2)))
+        src_tbl.putcol("PROPER_MOTION", np.broadcast_to(adir / 100.0, (nsrcs, 2)))
+        # SOURCE_MODEL is optional and its type is TableRecord!
+        src_tbl.removecols(["SOURCE_MODEL"])
+
+    with tables.table(mspath, ack=False, readonly=False) as main:
+        main.putkeyword("SOURCE", f"Table: {mspath}/SOURCE")
+
+
+def gen_subt_pointing(mspath: str):
+    """
+    Populate POINTING subtable, with antenna-based pointing info
+
+    Very rudimentary.
+    """
+    # with open_opt_subtable(mspath, "POINTING") as tbl:
+    nrows = 1
+    with tables.table(mspath + "::POINTING", ack=False, readonly=False) as tbl:
+        tbl.addrows(nrows)
+        tbl.putcol("ANTENNA_ID", 0)
+        tbl.putcol("TIME", 2e9)
+        tbl.putcol("INTERVAL", 1e12)
+        tbl.putcol("NAME", "test_pointing_name")
+        tbl.putcol("NUM_POLY", 0)
+        tbl.putcol("TIME_ORIGIN", 1e9)
+        adir = np.deg2rad([28.98, 34.03])
+        tbl.putcol("DIRECTION", np.broadcast_to(adir, (nrows, 1, 2)))
+        tbl.putcol("TARGET", np.broadcast_to(adir + 0.01, (nrows, 1, 2)))
+        tbl.putcol("TRACKING", True)
+
+
+# Other, more secondary subtables
+
+
+def gen_subt_feed(mspath: str, feed_descr: dict, ant_descr: str, spw_descr: str):
+    """
+    Populate FEED subtable, with antenna-based pointing info.
+
+    The table is filled for a single FEED_ID (0), for all the available
+    antenna IDs and spectral window IDs. The columns are filled with
+    roughtly similar values as seen in example ALMA MSs imported with
+    importasdm. BEAM_ID is left as -1 (optional BEAM subtable of MSv2 never
+    defined).
+
+    Parameters
+    ----------
+    mspath : str
+        path of output MS
+    feed_descr : dict
+        feed description, only one feed supported
+    ant_descr : str
+
+    spw_descr : str
+
+
+    Returns
+    -------
+
+    """
+
+    with tables.table(mspath + "::FEED", ack=False, readonly=False) as tbl:
+        nfeeds = len(feed_descr)
+        nspws = len(spw_descr)
+        nants = len(ant_descr)
+        nrows = nants * nspws * nfeeds
+        tbl.addrows(nrows)
+        tbl.putcol("ANTENNA_ID", np.tile(np.arange(nants), int(nrows / nants)))
+        tbl.putcol("FEED_ID", np.repeat(0, (nrows)))
+        tbl.putcol(
+            "SPECTRAL_WINDOW_ID", np.repeat(list(spw_descr.values()), (nrows / nspws))
+        )
+        tbl.putcol("TIME", np.broadcast_to(0, (nrows)))
+        tbl.putcol("INTERVAL", np.broadcast_to(5e9, (nrows)))
+        nrecep = 2
+        tbl.putcol("NUM_RECEPTORS", np.broadcast_to(nrecep, (nrows)))
+        tbl.putcol("BEAM_ID", np.broadcast_to(-1, (nrows)))
+        boff = np.deg2rad([0.1, 0.3])
+        tbl.putcol("BEAM_OFFSET", np.broadcast_to(boff, (nrows, 2, nrecep)))
+        tbl.putcol("POLARIZATION_TYPE", np.broadcast_to(["test_X, test_Y"], (nrows, 1)))
+        tbl.putcol("POL_RESPONSE", np.broadcast_to(0.0, (nrows, 2, nrecep)))
+        tbl.putcol("POSITION", np.broadcast_to([0.0, 0.0, 0.0], (nrows, 3)))
+        tbl.putcol("RECEPTOR_ANGLE", np.broadcast_to([1.51, 0.33], (nrows, nrecep)))
+
+
+def gen_subt_observation(mspath: str, obs_descr: dict):
+    """
+    Populate the OBSERVATION table, with one row per observation id/number
+    (MSv2: the id is implicitly the row number).
+    The string columns are filled with values loosely based on example ALMA
+    MSs.
+
+    Parameters
+    ----------
+    mspath : str
+        path of output MS
+    obs_descr : dict
+        obs description, with IDs, only the len is considered
+
+    Returns
+    -------
+
+    """
+
+    nobs = len(obs_descr)
+    with tables.table(mspath + "::OBSERVATION", ack=False, readonly=False) as tbl:
+        tbl.addrows(nobs)
+        # no keys, all data cols:
+        # "test_telescope" would produce errors for example in listobs:
+        # Exception: Telescope test_telescope is not recognized by CASA.
+        # (casa6core::MPosition casa6core::MSMetaData::getObservatoryPosition())
+        tbl.putcol("TELESCOPE_NAME", np.repeat("ALMA", nobs))
+        tbl.putcol("TIME_RANGE", np.broadcast_to([[4.87021e9, 4.87022e9]], (nobs, 2)))
+        tbl.putcol("OBSERVER", np.repeat("Dr. test_observer", nobs))
+        tbl.putcol(
+            "LOG", np.broadcast_to(["test_obs_log_1", "test_obs_log_2"], (nobs, 2))
+        )
+        tbl.putcol("SCHEDULE_TYPE", np.repeat("test_schedule_type", nobs))
+        sched = np.array(
+            [
+                [
+                    f"SchedulingBlock uid://A002/X1ftest/Xde{idx}",
+                    f"ExecBlock uid://A002/X1abtest/X123{idx}",
+                ]
+                for idx in range(nobs)
+            ]
+        )
+        tbl.putcol("SCHEDULE", sched)
+        proj = np.array([f"uid://A002/X1ftest/X4ec{idx}" for idx in range(nobs)])
+        tbl.putcol("PROJECT", proj)
+        tbl.putcol("RELEASE_DATE", np.repeat(0, nobs))
+
+
+def gen_subt_processor(mspath: str, proc_descr: dict):
+    """
+    Populate the PROCESSOR table, with one row per processor id/number
+    (MSv2: the id is implicitly the row number). The TYPE_ID is left to -1.
+    All values of TYPE are CORRELATOR.
+    MODE_ID are also left to -1 (no ..._MODE subtable).
+    The string columns are filled with values loosely based on example ALMA
+    MSs.
+
+    Parameters
+    ----------
+    mspath : str
+        path of output MS
+    proc_descr : dict
+        processors description, with IDs, only the len is considered
+
+    Returns
+    -------
+
+    """
+
+    nproc = len(proc_descr)
+    with tables.table(mspath + "::PROCESSOR", ack=False, readonly=False) as tbl:
+        tbl.addrows(nproc)
+        # no keys, all data cols:
+        # There could also be RADIOMETER, SPECTROMETER, PULSAR-TIMER, etc. - not nor now
+        tbl.putcol("TYPE", np.repeat("CORRELATOR", nproc))
+        tbl.putcol("SUB_TYPE", np.repeat("test_CORRELATOR_MODE", nproc))
+        tbl.putcol("TYPE_ID", np.repeat(-1, nproc))
+        tbl.putcol("MODE_ID", np.repeat(-1, nproc))
+        tbl.putcol("FLAG_ROW", np.repeat(False, nproc))
+
+
+def gen_subt_flag_cmd(mspath: str):
+    """
+    Leaves the FLAG_CMD subtable empty for now, and checks that there are no
+    rows.
+    """
+    with tables.table(mspath + "::FLAG_CMD", ack=False, readonly=False) as tbl:
+        assert tbl.nrows() == 0
+
+
+def gen_subt_history(mspath: str, obs_descr: dict):
+    """
+    Populate the HISTORY table, with only one row per observation
+    The string columns are filled with values loosely based on example ALMA MSs.
+    OBJECT_ID is left all to -1.
+
+    Parameters
+    ----------
+    mspath : str
+        path of output MS
+    obs_descr : dict
+        obs description, with IDs, only the len is considered
+
+    Returns
+    -------
+
+    """
+
+    nobs = len(obs_descr)
+    with tables.table(mspath + "::HISTORY", ack=False, readonly=False) as tbl:
+        tbl.addrows(nobs)
+        # keys
+        tbl.putcol("TIME", np.repeat(0, nobs))
+        tbl.putcol("OBSERVATION_ID", np.arange(nobs))
+        # data
+        tbl.putcol("MESSAGE", np.repeat("made with test ms generator", nobs))
+        tbl.putcol("PRIORITY", np.repeat("INFO", nobs))
+        tbl.putcol("ORIGIN", np.repeat("ms_maker", nobs))
+        tbl.putcol("OBJECT_ID", np.repeat(0, nobs))
+        tbl.putcol("APPLICATION", np.repeat("xradio", nobs))
+        tbl.putcol("CLI_COMMAND", np.broadcast_to("gen_subt_history", (nobs, 1)))
+        tbl.putcol("APP_PARAMS", np.broadcast_to("", (nobs, 1)))
+
+
+def gen_subt_syscal(mspath: str):
+    """
+    Creates a SYSCAL subtable and populates it with a (very incomplete) row
+    This is just to enable minimal coverage of some WEATHER handling code in
+    the casacore tables read/write functions.
+    """
+    with open_opt_subtable(mspath, "SYSCAL") as wtbl:
+        wtbl.addrows(1)
+        wtbl.putcol("ANTENNA_ID", 0)
+        wtbl.putcol("FEED_ID", 0)
+        wtbl.putcol("SPECTRAL_WINDOW_ID", 0)
+        wtbl.putcol("TIME", 1e10)
+        wtbl.putcol("INTERVAL", 1e12)
+        # all data/flags columns in the WEATHER table are optional!
+
+
+def gen_subt_weather(mspath: str):
+    """
+    Creates a WEATHER subtable and populates it with a (very incomplete) row
+    simply with a very high TIME value, as seen in some corner cases of
+    test MSs.
+    This is just to enable minimal coverage of some WEATHER handling code in
+    the casacore tables read/write functions.
+    """
+    with open_opt_subtable(mspath, "WEATHER") as wtbl:
+        wtbl.addrows(1)
+        wtbl.putcol("ANTENNA_ID", 0)
+        wtbl.putcol("TIME", 1e12)
+        wtbl.putcol("INTERVAL", 1e12)
+        # all data/flags columns in the WEATHER table are optional!
+
+
+def gen_subt_asdm_receiver(mspath: str):
+    """
+    Produces an empty table, for basic coverage of ASDM_* subtables handling
+    code.
+    Simply creates an empty table and checks no rwos
+    """
+    rec_path = Path(mspath) / "ASDM_RECEIVER"
+    tabdesc = {
+        "receiverId": {
+            "valueType": "int",
+            "dataManagerType": "StandardStMan",
+            "dataManagerGroup": "StandardStMan",
+            "option": 0,
+            "maxlen": 0,
+            "comment": "comment...",
+            "keywords": {},
+        },
+        "spectralWindowId": {
+            "valueType": "int",
+            "dataManagerType": "StandardStMan",
+            "dataManagerGroup": "StandardStMan",
+            "option": 0,
+            "maxlen": 0,
+            "comment": "comment...",
+            "keywords": {},
+        },
+        "timeInterval": {
+            "valueType": "double",
+            "dataManagerType": "StandardStMan",
+            "dataManagerGroup": "StandardStMan",
+            "option": 0,
+            "maxlen": 0,
+            "comment": "comment...",
+            "keywords": {},
+        },
+    }
+
+    with tables.table(
+        str(rec_path), tabledesc=tabdesc, nrow=1, readonly=False, ack=False
+    ) as tbl:
+        tbl.putcol("receiverId", 0)
+        tbl.putcol("spectralWindowId", 0)
+        tbl.putcol("timeInterval", 0)

--- a/tests/unit/vis/test_vis_io.py
+++ b/tests/unit/vis/test_vis_io.py
@@ -1,6 +1,6 @@
 import os
+from pathlib import Path
 import pytest
-import shutil
 
 # using unittest.mock, we could add pytest_mock to dependencies
 from unittest.mock import patch
@@ -179,19 +179,14 @@ def test_load_chunk_ms_alma(ms_alma_antennae_north_split):
     check_cds(vis, subtables=[], chunks=True)
 
 
-def clear_output(path):
-    if os.path.lexists(path):
-        shutil.rmtree(path)
-
-
 @patch("xradio.vis._vis_utils.zarr.write_vis")
-def test_write_vis_empty(mock_write_vis):
+def test_write_vis_empty(mock_write_vis, tmp_path):
     from xradio.vis import write_vis
     from xradio.vis._vis_utils._utils.cds import CASAVisSet
     import xarray
 
     cds = CASAVisSet({}, {(0, 0, "intent"): xarray.Dataset()}, "empty vis set")
-    outname = "test_vis_empty.zarr"
+    outname = Path(tmp_path, "test_vis_empty.zarr")
     write_vis(cds, outname, out_format="zarr")
     assert mock_write_vis.called_once()
     assert mock_write_vis.call_args[0] == (cds, outname, None, None)

--- a/tests/unit/vis/test_vis_io.py
+++ b/tests/unit/vis/test_vis_io.py
@@ -5,7 +5,7 @@ import shutil
 # using unittest.mock, we could add pytest_mock to dependencies
 from unittest.mock import patch
 
-from xradio.vis._vis_utils._utils.cds_checks import check_cds
+from .ms_test_utils.cds_checks import check_cds
 
 
 @patch("xradio.vis._vis_utils.ms.read_ms")

--- a/tests/unit/vis/test_vis_io.py
+++ b/tests/unit/vis/test_vis_io.py
@@ -1,0 +1,207 @@
+import os
+import pytest
+import shutil
+
+# using unittest.mock, we could add pytest_mock to dependencies
+from unittest.mock import patch
+
+from xradio.vis._vis_utils._utils.cds_checks import check_cds
+
+
+@patch("xradio.vis._vis_utils.ms.read_ms")
+def test_read_vis_minimal_defaults(mock_read_ms, ms_minimal_required):
+    from xradio.vis import read_vis
+
+    vis = read_vis(ms_minimal_required.fname)
+    assert mock_read_ms.called_once()
+    assert mock_read_ms.call_args[0] == (
+        ms_minimal_required.fname,
+        True,
+        False,
+        "intent",
+        None,
+        False,
+    )
+
+
+def test_read_vis_minimal_raises_from_read_ms(ms_minimal_required):
+    from xradio.vis import read_vis
+
+    with patch("xradio.vis._vis_utils.ms.read_ms", side_effect=RuntimeError):
+        with pytest.raises(RuntimeError):
+            vis = read_vis(ms_minimal_required.fname)
+
+
+@patch("xradio.vis._vis_utils.ms.read_ms")
+def test_read_vis_minimal_by_ddi(mock_read_ms, ms_minimal_required):
+    from xradio.vis import read_vis
+
+    scheme = "ddi"
+    vis = read_vis(ms_minimal_required.fname, partition_scheme=scheme)
+    assert mock_read_ms.called_once()
+    assert mock_read_ms.call_args[0] == (
+        ms_minimal_required.fname,
+        True,
+        False,
+        "ddi",
+        None,
+        False,
+    )
+
+
+def test_read_nonexisting_ms():
+    from xradio.vis import read_vis
+
+    with pytest.raises(ValueError, match="invalid input"):
+        vis = read_vis("non-existing-input-vis-tmp.ms")
+        assert vis
+
+
+def test_read_empty_ms_required(ms_empty_required):
+    from xradio.vis import read_vis
+
+    with pytest.raises(
+        AttributeError, match="object has no attribute 'spectral_window_id'"
+    ):
+        vis = read_vis(ms_empty_required.fname)
+        assert vis.metainfo
+
+
+def test_read_ms_required(ms_minimal_required):
+    from xradio.vis import read_vis
+
+    vis = read_vis(ms_minimal_required.fname)
+    assert vis.metainfo
+    check_cds(vis)
+
+
+def test_read_empty_ms_complete(ms_empty_complete):
+    from xradio.vis import read_vis
+
+    with pytest.raises(
+        AttributeError, match="object has no attribute 'spectral_window_id'"
+    ):
+        vis = read_vis(ms_empty_complete.fname)
+        assert vis.metainfo
+
+
+def test_read_vis_zarr(vis_zarr_empty):
+    from xradio.vis import read_vis
+
+    with pytest.raises(
+        ValueError, match="invalid input filename to read_generic_table"
+    ):
+        vis = read_vis(vis_zarr_empty, asdm_subtables=True)
+        assert vis
+
+
+# TODO: same but now with "ms_minimal_required"  - same with all tests that use ms_empty_required/complete => ms_minimal_required/ms_minimal_complete
+def test_load_vis_block_empty_ms_required(ms_empty_required):
+    from xradio.vis import load_vis_block
+
+    chunk = {
+        "time": slice(0, 8),
+        "baseline": slice(0, 10),
+        "freq": slice(0, 40),
+        "pol": slice(0, 2),
+    }
+
+    vis = load_vis_block(ms_empty_required.fname, chunk, (0, 0, "intent"))
+    assert vis
+    assert vis.partitions
+    assert vis.metainfo == {}
+
+
+def test_load_vis_block_empty_ms_required_all_times(ms_empty_required):
+    from xradio.vis import load_vis_block
+
+    chunk = {
+        # "time": slice(0, 8),
+        "baseline": slice(0, 10),
+        "freq": slice(0, 40),
+        "pol": slice(0, 2),
+    }
+
+    vis = load_vis_block(ms_empty_required.fname, chunk, (0, 0, "intent"))
+    assert vis
+    assert vis.partitions
+    assert vis.metainfo == {}
+
+
+def test_load_vis_block_empty_ms_complete(ms_empty_complete):
+    from xradio.vis import load_vis_block
+
+    chunk = {
+        "time": slice(0, 8),
+        "baseline": slice(0, 10),
+        "freq": slice(0, 40),
+        "pol": slice(0, 2),
+    }
+
+    vis = load_vis_block(ms_empty_complete.fname, chunk, (0, 1, "other intent"))
+    assert vis
+    assert vis.partitions
+    assert vis.metainfo == {}
+
+
+def test_load_vis_block_ms_min(ms_minimal_required):
+    from xradio.vis import load_vis_block
+
+    chunk = {
+        "time": slice(0, 8),
+        "baseline": slice(0, 4),
+        "freq": slice(0, 10),
+        "pol": slice(0, 2),
+    }
+
+    vis = load_vis_block(
+        ms_minimal_required.fname, chunk, (0, 0, "scan_intent#subscan_intent")
+    )
+    assert vis
+    assert vis.partitions
+    assert vis.metainfo == {}
+
+
+def test_load_chunk_ms_vlass(ms_vlass_subset_evla_36473386):
+    from xradio.vis import load_vis_block
+
+    chunk = {
+        "time": slice(0, 8),
+        "baseline": slice(0, 4),
+        "freq": slice(0, 10),
+        "pol": slice(0, 2),
+    }
+
+    vis = load_vis_block(
+        ms_vlass_subset_evla_36473386.fname, chunk, (0, 0, "scan_intent#subscan_intent")
+    )
+    check_cds(vis, subtables=[], chunks=True)
+
+
+def clear_output(path):
+    if os.path.lexists(path):
+        shutil.rmtree(path)
+
+
+@patch("xradio.vis._vis_utils.zarr.write_vis")
+def test_write_vis_empty(mock_write_vis):
+    from xradio.vis import write_vis
+    from xradio.vis._vis_utils._utils.cds import CASAVisSet
+    import xarray
+
+    cds = CASAVisSet({}, {(0, 0, "intent"): xarray.Dataset()}, "empty vis set")
+    outname = "test_vis_empty.zarr"
+    write_vis(cds, outname, out_format="zarr")
+    assert mock_write_vis.called_once()
+    assert mock_write_vis.call_args[0] == (cds, outname, None, None)
+
+
+@patch("xradio.vis._vis_utils.zarr.write_vis")
+def test_write_vis_unsupported(mock_write_vis):
+    """unsuported out_format"""
+    from xradio.vis import write_vis
+
+    with pytest.raises(ValueError, match="Unsupported output format"):
+        write_vis({}, out_format="asdm", outpath="uns.asdm")
+
+    assert not mock_write_vis.called

--- a/tests/unit/vis/test_vis_io.py
+++ b/tests/unit/vis/test_vis_io.py
@@ -162,7 +162,8 @@ def test_load_vis_block_ms_min(ms_minimal_required):
     assert vis.metainfo == {}
 
 
-def test_load_chunk_ms_vlass(ms_vlass_subset_evla_36473386):
+@pytest.mark.uses_download
+def test_load_chunk_ms_alma(ms_alma_antennae_north_split):
     from xradio.vis import load_vis_block
 
     chunk = {
@@ -173,7 +174,7 @@ def test_load_chunk_ms_vlass(ms_vlass_subset_evla_36473386):
     }
 
     vis = load_vis_block(
-        ms_vlass_subset_evla_36473386.fname, chunk, (0, 0, "scan_intent#subscan_intent")
+        ms_alma_antennae_north_split.fname, chunk, (0, 0, "scan_intent#subscan_intent")
     )
     check_cds(vis, subtables=[], chunks=True)
 


### PR DESCRIPTION
This adds unit tests for `vis/_vis_utils`.
So far in `tests/unit/vis` we only had a few unit tests for `optimised_functions.py`
This PR adds a set of unit tests (230+) to cover the code under src/xradio/vis/_vis_utils. It adds a `conftest` with pytest fixtures, and an on-the-fly test MS geneator used in these tests. It also includes a few fixes for corner cases in the _tables read/write functions.

All pytests tests runtime before: ~55s, after: 1m25s
Coverage (all repo) before: 65%, after: 87%

 ---
Note well:
```
This contribution is made under the current ALMA software agreements.
(c) European Southern Observatory, 2024
Copyright by ESO (in the framework of the ALMA collaboration)
```
