### PR TITLE
Fix  test_get_pad_nan_feed1 error on MacOS

### DIFF
--- a/.github/workflows/python-testing-macos.yml
+++ b/.github/workflows/python-testing-macos.yml
@@ -2,8 +2,6 @@ name: MacOS
 
 on:
   push:
-    branches:
-      - main
     paths-ignore:
       - '**.md'
       - '**.rst'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     'graphviper',
     'matplotlib',
     'numba>=0.57.0',
-    'numpy==1.25.0',
+    'numpy',
     'prettytable',
     'pytest',
     'pytest-cov',

--- a/tests/unit/vis/_vis_utils/_ms/_tables/test_read.py
+++ b/tests/unit/vis/_vis_utils/_ms/_tables/test_read.py
@@ -126,7 +126,9 @@ def test_get_pad_nan_feed1(main_xds_min):
     from xradio.vis._vis_utils._ms._tables.read import get_pad_nan
 
     res = get_pad_nan(main_xds_min.data_vars["feed1_id"])
-    assert res == -2147483648
+    # Beware, with integer types this can be different integer values
+    # depending on platform (https://github.com/numpy/numpy/issues/21166)
+    assert res == np.array([np.nan]).astype(np.int32)
 
 
 def test_redimension_ms_subtable_source(source_xds_min):


### PR DESCRIPTION
The failure is harmless in principle I think. Here is an attempt to fix the test without removing it. 

The failure is a manifestation of https://github.com/numpy/numpy/issues/21166 "Conversion of numpy.nan to int gives inconsistent results" causing different behavior between platforms, for example: https://github.com/aai-institute/pyDVL/issues/474

This discrepancy should not be a big deal but could bite us if we end up having integer data variables in the final schema.
For example missing "time-baseline" rows in the MS, become "np.nan" values in xdss, with the caveat that for integer data variables they would get whatever special value an np.nan is converted to. It turns out that:
- on linux, nan converted to int32 => -2147483648
- on linux, nan converted to int64 => -9223372036854775808
- but on mac (M1 it seems), nan converted to int => 0
Those 0s could cause ambiguities, but I'd hope that the changes in the xradio schema with respect to the cngi-io schema will remove most if not all those potential ambiguities (especially with ID variables).





 ---
Note well:
```
This contribution is made under the current ALMA software agreements.
(c) European Southern Observatory, 2024
Copyright by ESO (in the framework of the ALMA collaboration)
```