### PR TITLE
Fix warnings triggered in vis tests

### DIFF
--- a/src/xradio/vis/_vis_utils/_ms/_tables/read.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read.py
@@ -789,8 +789,13 @@ def read_col_chunk(
             elif len(cshape) == 4:  # DATA and FLAG
                 data = query.getcolslice(col, (d1[0], d2[0]), (d1[1], d2[1]), [], 0, -1)
 
-    # full data is the maximum of the data shape and chunk shape dimensions
-    fulldata = np.full(cshape, np.nan, dtype=data.dtype)
+    policy = "warn"
+    if np.issubdtype(data.dtype, np.integer):
+        policy = "ignore"
+    with np.errstate(invalid=policy):
+        # full data is the maximum of the data shape and chunk shape dimensions
+        fulldata = np.full(cshape, np.nan, dtype=data.dtype)
+
     if len(didxs) > 0:
         fulldata[tidxs[didxs], bidxs[didxs]] = data[didxs]
 

--- a/src/xradio/vis/_vis_utils/_ms/subtables.py
+++ b/src/xradio/vis/_vis_utils/_ms/subtables.py
@@ -13,7 +13,7 @@ from ._tables.read_subtables import read_ephemerides, read_delayed_pointing_tabl
 
 subt_rename_ids = {
     "ANTENNA": {"row": "antenna_id", "dim_1": "xyz"},
-    "FEED": {"dim_1": "xyz", "dim_2": "receptor", "dim_3": "receptor"},
+    "FEED": {"dim_1": "xyz", "dim_2": "receptor", "dim_3": "receptor2"},
     "FIELD": {"row": "field_id", "dim_1": "poly_id", "dim_2": "ra/dec"},
     "FREQ_OFFSET": {"antenna1": "antenna1_id", "antenna2": "antenna2_id"},
     "OBSERVATION": {"row": "observation_id", "dim_1": "start/end"},

--- a/src/xradio/vis/_vis_utils/_utils/xds_helper.py
+++ b/src/xradio/vis/_vis_utils/_utils/xds_helper.py
@@ -187,8 +187,9 @@ def flatten_xds(xds: xr.Dataset) -> xr.Dataset:
             else:
                 astyped_data_vars[dv] = txds[dv]
 
-        flat_xds = xr.Dataset(astyped_data_vars, coords=txds.coords,
-                               attrs=txds.attrs)
+        flat_xds = xr.Dataset(astyped_data_vars, coords=txds.coords, attrs=txds.attrs)
+        flat_xds = flat_xds.reset_index(["time", "baseline"])
+
     else:
         flat_xds = txds
 

--- a/src/xradio/vis/_vis_utils/_utils/xds_helper.py
+++ b/src/xradio/vis/_vis_utils/_utils/xds_helper.py
@@ -163,7 +163,9 @@ def flatten_xds(xds: xr.Dataset) -> xr.Dataset:
     """
     flatten (time, baseline) dimensions of xds back to single dimension (row)
     """
-    nan_int = np.array([np.nan]).astype("int32")[0]
+    # known invalid cast warning when casting to integer
+    with np.errstate(invalid="ignore"):
+        nan_int = np.array([np.nan]).astype("int32")[0]
     txds = xds.copy()
 
     # flatten the time x baseline dimensions of main table

--- a/src/xradio/vis/_vis_utils/_utils/xds_helper.py
+++ b/src/xradio/vis/_vis_utils/_utils/xds_helper.py
@@ -178,7 +178,8 @@ def flatten_xds(xds: xr.Dataset) -> xr.Dataset:
             drop=True,
         )  # .unify_chunks()
         for dv in list(xds.data_vars):
-            txds[dv] = txds[dv].astype(xds[dv].dtype)
+            if txds[dv].dtype != xds[dv].dtype:
+                txds[dv] = txds[dv].astype(xds[dv].dtype)
 
     return txds
 

--- a/tests/unit/vis/_vis_utils/_ms/_tables/test_read.py
+++ b/tests/unit/vis/_vis_utils/_ms/_tables/test_read.py
@@ -128,7 +128,9 @@ def test_get_pad_nan_feed1(main_xds_min):
     res = get_pad_nan(main_xds_min.data_vars["feed1_id"])
     # Beware, with integer types this can be different integer values
     # depending on platform (https://github.com/numpy/numpy/issues/21166)
-    assert res == np.array([np.nan]).astype(np.int32)
+    with np.errstate(invalid="ignore"):
+        expected_nan = np.array([np.nan]).astype(np.int32)
+    assert res == expected_nan
 
 
 def test_redimension_ms_subtable_source(source_xds_min):

--- a/tests/unit/vis/_vis_utils/_utils/test_xds_helper.py
+++ b/tests/unit/vis/_vis_utils/_utils/test_xds_helper.py
@@ -94,6 +94,7 @@ def test_expand_xds_ddi_min(main_xds_flat_min):
     assert res
     assert all([coord in res.coords for coord in ["baseline", "time"]])
 
+
 def test_flatten_xds_empty():
     from xradio.vis._vis_utils._utils.xds_helper import flatten_xds
 
@@ -104,17 +105,26 @@ def test_flatten_xds_empty():
 
 def test_flatten_xds_main_min(main_xds_min):
     from xradio.vis._vis_utils._utils.xds_helper import flatten_xds
+
+    res = flatten_xds(main_xds_min)
+    assert all(
+        [dim in res.dims for dim in ["row", "uvw_coords", "freq", "pol", "antenna_id"]]
+    )
+
+
+def test_flatten_then_expand_xds_main_min(main_xds_min):
+    from xradio.vis._vis_utils._utils.xds_helper import flatten_xds
     from xradio.vis._vis_utils._utils.xds_helper import expand_xds
 
     res = flatten_xds(main_xds_min)
-    assert [
-        dim in res.dims for dim in ["row", "uvw_coords", "freq", "pol", "antenna_id"]
-    ]
-    # A separate test/fixture would be better?
-    print(f" Thse are {res.dims=}, {res.coords=}")
-    print(f" This is {res.data_vars=}")
     res = res.drop_vars("baseline")
     res_expanded = expand_xds(res)
+    assert all(
+        [
+            dim in res_expanded.dims
+            for dim in ["time", "baseline", "uvw_coords", "freq", "pol", "antenna_id"]
+        ]
+    )
 
 
 BYTES_TO_GB = 1024 * 1024 * 1204

--- a/tests/unit/vis/_vis_utils/_utils/test_xds_helper.py
+++ b/tests/unit/vis/_vis_utils/_utils/test_xds_helper.py
@@ -78,7 +78,7 @@ def test_make_global_coords_min(ms_minimal_required):
         assert res
 
 
-def test_expand_xds():
+def test_expand_xds_empty():
     from xradio.vis._vis_utils._utils.xds_helper import expand_xds
 
     empty = xarray.Dataset()
@@ -87,19 +87,12 @@ def test_expand_xds():
         assert "baseline" in res.data_vars
 
 
-def test_expand_xds_ddi_min(ms_minimal_required):
+def test_expand_xds_ddi_min(main_xds_flat_min):
     from xradio.vis._vis_utils._utils.xds_helper import expand_xds
-    from xradio.vis._vis_utils.ms import read_ms
 
-    # TODO: fixture for an xds (main)
-    cds = read_ms(ms_minimal_required.fname, partition_scheme="ddi", expand=False)
-    xds = list(cds.partitions.values())[0]
-
-    with pytest.raises(AssertionError, match=""):
-        res = expand_xds(xds)
-        assert res
-        assert "baseline" in res.coords
-
+    res = expand_xds(main_xds_flat_min)
+    assert res
+    assert all([coord in res.coords for coord in ["baseline", "time"]])
 
 def test_flatten_xds_empty():
     from xradio.vis._vis_utils._utils.xds_helper import flatten_xds
@@ -121,7 +114,6 @@ def test_flatten_xds_main_min(main_xds_min):
     print(f" Thse are {res.dims=}, {res.coords=}")
     print(f" This is {res.data_vars=}")
     res = res.drop_vars("baseline")
-    # with pytest.raises(AttributeError, "has no attribute"
     res_expanded = expand_xds(res)
 
 


### PR DESCRIPTION
Fixes warnings triggered in vis unit tests.

Most of the warnings had to do with casts or with deprecated operations on pandas indices.

---
Note well:
```
This contribution is made under the current ALMA software agreements.
(c) European Southern Observatory, 2024
Copyright by ESO (in the framework of the ALMA collaboration)
```

