### PR TITLE
Fix reference frame conversion

### DIFF
--- a/src/xradio/vis/_vis_utils/_ms/msv2_to_msv4_meta.py
+++ b/src/xradio/vis/_vis_utils/_ms/msv2_to_msv4_meta.py
@@ -1,3 +1,5 @@
+import graphviper.utils.logger as logger
+
 col_to_data_variable_names = {
     "FLOAT_DATA": "SPECTRUM",
     "DATA": "VISIBILITY",
@@ -26,16 +28,36 @@ col_to_coord_names = {
     "ANTENNA2": "baseline_ant2_id",
 }
 
+# Map casacore measures to astropy
 casacore_to_msv4_measure_type = {
-    "quanta": {"type": "quantity", "Ref": None},
-    "direction": {"type": "sky_coord", "Ref": "frame"},
-    "epoch": {"type": "time", "Ref": "scale"},
-    "frequency": {"type": "spectral_coord", "Ref": "frame"},
-    "position": {"type": "earth_location", "Ref": "ellipsoid"},
-    "uvw": {"type": "uvw", "Ref": "frame"},
+    "quanta": {
+        "type": "quantity",
+    },
+    "direction": {"type": "sky_coord", "Ref": "frame", "Ref_map": {"J2000": "fk5"}},
+    "epoch": {"type": "time", "Ref": "scale", "Ref_map": {"UTC": "utc"}},
+    "frequency": {
+        "type": "spectral_coord",
+        "Ref": "frame",
+        "Ref_map": {
+            "REST": "REST",
+            "LSRK": "LSRK",
+            "LSRD": "LSRD",
+            "BARY": "BARY",
+            "GEO": "GEO",
+            "TOPO": "TOPO",
+            "GALACTO": "GALACTO",
+            "LGROUP": "LGROUP",
+            "CMB": "CMB",
+            "Undefined": "Undefined",
+        },
+    },
+    "position": {
+        "type": "earth_location",
+        "Ref": "ellipsoid",
+        "Ref_map": {"ITRF": "GRS80"},
+    },
+    "uvw": {"type": "uvw", "Ref": "frame", "Ref_map": {"ITRF": "GRS80"}},
 }
-
-casacore_to_msv4_ref = {"J2000": "FK5", "ITRF": "GRS80"}
 
 casa_frequency_frames = [
     "REST",
@@ -60,42 +82,49 @@ def column_description_casacore_to_msv4_measure(
 
     msv4_measure = {}
     if "MEASINFO" in casacore_column_description["keywords"]:
-        msv4_measure["type"] = casacore_to_msv4_measure_type[
-            casacore_column_description["keywords"]["MEASINFO"]["type"]
-        ]["type"]
+        measinfo = casacore_column_description["keywords"]["MEASINFO"]
+
+        # Get conversion information
+        msv4_measure_conversion = casacore_to_msv4_measure_type[measinfo["type"]]
+
+        # Convert type, copy unit
+        msv4_measure["type"] = msv4_measure_conversion["type"]
         msv4_measure["units"] = list(
             casacore_column_description["keywords"]["QuantumUnits"]
         )
 
-        if "TabRefCodes" in casacore_column_description["keywords"]["MEASINFO"]:
-            ref_index = np.where(
-                casacore_column_description["keywords"]["MEASINFO"]["TabRefCodes"]
-                == ref_code
-            )[0][0]
-            casa_ref = casacore_column_description["keywords"]["MEASINFO"][
-                "TabRefTypes"
-            ][ref_index]
-        else:
-            if "Ref" in casacore_column_description["keywords"]["MEASINFO"]:
-                casa_ref = casacore_column_description["keywords"]["MEASINFO"]["Ref"]
-            elif (
-                casacore_column_description["keywords"]["MEASINFO"]["type"]
-                == "frequency"
-            ):
+        # Reference frame to convert?
+        if "Ref" in msv4_measure_conversion:
+            # Find reference frame
+            if "TabRefCodes" in measinfo:
+                ref_index = np.where(measinfo["TabRefCodes"] == ref_code)[0][0]
+                casa_ref = measinfo["TabRefTypes"][ref_index]
+            elif "Ref" in measinfo:
+                casa_ref = measinfo["Ref"]
+            elif measinfo["type"] == "frequency":
                 # Some MSv2 don't have the "TabRefCodes".
                 ref_index = np.where(casa_frequency_frames_codes == ref_code)[0][0]
                 casa_ref = casa_frequency_frames[ref_index]
+            else:
+                logger.warning(
+                    f"Could not determine {measinfo['type']} measure "
+                    "reference frame!"
+                )
 
-        if casa_ref in casacore_to_msv4_ref:
-            casa_ref = casacore_to_msv4_ref[casa_ref]
-        msv4_measure[
-            casacore_to_msv4_measure_type[
-                casacore_column_description["keywords"]["MEASINFO"]["type"]
-            ]["Ref"]
-        ] = casa_ref
+            # Convert into MSv4 representation of reference frame, warn if unknown
+            if casa_ref in msv4_measure_conversion.get("Ref_map", {}):
+                casa_ref = msv4_measure_conversion["Ref_map"][casa_ref]
+            else:
+                logger.warning(
+                    f"Unknown reference frame for {measinfo['type']} "
+                    f"measure, using verbatim: {casa_ref}"
+                )
+
+            msv4_measure[msv4_measure_conversion["Ref"]] = casa_ref
 
         if msv4_measure["type"] == "time":
-            msv4_measure["format"] = "unix"
+            msv4_measure["format"] = time_format
+
     return msv4_measure
 
 


### PR DESCRIPTION
Idea here is that we map to `astropy` arguments, which are typically lower case.

Also clean the conversion code up a bit more... It confused me quite a bit initially :)