### PR TITLE
Small fixes for corner case MSs from casatestdata

### DIFF
--- a/src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
@@ -626,14 +626,15 @@ def read_flat_main_table(
     if scan_state:
         # TODO: support additional intent/scan/subscan conditions if
         # we keep this read_flat functionality
-        _scans, states = scan_state
+        scans, states = scan_state
         # get row indices relative to full main table
-        if states is not None:
-            taql_where += (
-                f" AND SCAN_NUMBER = {scan_state[0]} AND STATE_ID = {scan_state[1]}"
-            )
-        else:
-            taql_where += f" AND SCAN_NUMBER = {scan_state[0]}"
+        if type(states) == np.ndarray:
+            state_ids_or = " OR STATE_ID = ".join(np.char.mod("%d", states))
+            taql_where += f" AND (STATE_ID = {state_ids_or})"
+        elif states is not None:
+            taql_where += f" AND AND STATE_ID = {state}"
+        elif scans is not None:
+            taql_where += f" AND SCAN_NUMBER = {scans}"
 
     mtable = tables.table(
         infile, readonly=True, lockoptions={"option": "usernoread"}, ack=False
@@ -647,6 +648,7 @@ def read_flat_main_table(
 
     nrows = len(rowidxs)
     if nrows == 0:
+        mtable.close()
         return xr.Dataset(), {}, {}
 
     part_ids = get_partition_ids(mtable, taql_where)

--- a/src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/read_main_table.py
@@ -632,7 +632,7 @@ def read_flat_main_table(
             state_ids_or = " OR STATE_ID = ".join(np.char.mod("%d", states))
             taql_where += f" AND (STATE_ID = {state_ids_or})"
         elif states is not None:
-            taql_where += f" AND AND STATE_ID = {state}"
+            taql_where += f" AND STATE_ID = {states}"
         elif scans is not None:
             taql_where += f" AND SCAN_NUMBER = {scans}"
 

--- a/tests/unit/vis/_vis_utils/test_ms.py
+++ b/tests/unit/vis/_vis_utils/test_ms.py
@@ -97,10 +97,8 @@ def test_read_ms_by_scan_with_expand(ms_minimal_required):
 def test_read_ms_by_intent_expand_raises(ms_minimal_required):
     from xradio.vis._vis_utils.ms import read_ms
 
-    # TODO: fixture for an xds (main)
-    with pytest.raises(RuntimeError, match="Error in TaQL command"):
-        cds = read_ms(ms_minimal_required.fname, partition_scheme="intent", expand=True)
-        assert cds
+    cds = read_ms(ms_minimal_required.fname, partition_scheme="intent", expand=True)
+    assert cds
 
 
 # def test_load_vis_chunk_empty_required(ms_empty_required):


### PR DESCRIPTION
With this xradio can read/convert all MSs from CASA's casatestdata and stakeholder tests.
Fixes #185.


Note well:
```
This contribution is made under the current ALMA software agreements.
(c) European Southern Observatory, 2024
Copyright by ESO (in the framework of the ALMA collaboration)
```