### PR TITLE
Fix processing set freq axis, remove debugging output

### DIFF
--- a/src/xradio/vis/_processing_set.py
+++ b/src/xradio/vis/_processing_set.py
@@ -106,8 +106,8 @@ class processing_set(dict):
             assert (
                 frame == ms_xds.frequency.attrs["frame"]
             ), "Frequency reference frame not consistent in processing set."
-            if ms_xds.frequency.attrs["spw_id"] not in spw_ids:
-                spw_ids.append(ms_xds.frequency.attrs["spw_id"])
+            if ms_xds.frequency.attrs["spectral_window_id"] not in spw_ids:
+                spw_ids.append(ms_xds.frequency.attrs["spectral_window_id"])
                 freq_axis_list.append(ms_xds.frequency)
 
         freq_axis = xr.concat(freq_axis_list, dim="frequency").sortby("frequency")

--- a/src/xradio/vis/read_processing_set.py
+++ b/src/xradio/vis/read_processing_set.py
@@ -37,8 +37,6 @@ def read_processing_set(
         xds = _open_dataset(ms_main_store, file_system)
         data_groups = xds.attrs["data_groups"]
 
-        print(xds)
-
         if (intents is None) or (xds.attrs["partition_info"]["intent"] in intents):
             sub_xds_dict, field_and_source_xds_dict = _read_sub_xds(
                 ms_store, file_system=file_system, data_groups=data_groups


### PR DESCRIPTION
Changed frequency spw attribute name in processing_set._get_ps_freq_axis from "spw_id" to "spectral_window_id"

Also removed print(xds) line in read_processing_set.

Test failures due to not failures downloading test ms/table (?)