### PR TITLE
Lofar performance improvements

### DIFF
--- a/src/xradio/vis/_vis_utils/_ms/_tables/table_query.py
+++ b/src/xradio/vis/_vis_utils/_ms/_tables/table_query.py
@@ -22,3 +22,33 @@ def open_query(table: tables.table, query: str) -> Generator[tables.table, None,
         yield ttq
     finally:
         ttq.close()
+
+
+class TableManager:
+
+    def __init__(
+        self,
+        infile: str,
+        taql_where: str = "",
+    ):
+        self.infile = infile
+        self.taql_where = taql_where
+        self.taql_query = taql_where.replace("where ", "")
+
+        # Store the base table so it doesn't have to be reopened when calling `get_table()`
+
+    def get_base(self):
+        # Returns a new table object
+        return tables.table(
+            self.infile, readonly=True, lockoptions={"option": "usernoread"}, ack=False
+        )
+
+    def get_table(self):
+        # Performance note:
+        # table.query("(DATA_DESC_ID = 0)") is slightly faster than
+        # tables.taql("select * from $table (DATA_DESC_ID = 0)")
+        with tables.table(
+            self.infile, readonly=True, lockoptions={"option": "usernoread"}, ack=False
+        ) as mtable:
+            query = f"select * from $mtable {self.taql_where}"
+            return tables.taql(query)

--- a/src/xradio/vis/_vis_utils/_ms/conversion.py
+++ b/src/xradio/vis/_vis_utils/_ms/conversion.py
@@ -738,6 +738,10 @@ def convert_and_write_partition(
         _description_, by default "zarr"
     overwrite : bool, optional
         _description_, by default False
+    lofar : bool, optional
+        _description_, by default False
+    lofar_read_size : int, optional
+        _description_, by default 1024
 
     Returns
     -------

--- a/src/xradio/vis/_vis_utils/_zarr/encoding.py
+++ b/src/xradio/vis/_vis_utils/_zarr/encoding.py
@@ -1,3 +1,5 @@
+import dask.array as da
+
 def add_encoding(xds, compressor, chunks=None):
     if chunks is None:
         chunks = xds.sizes
@@ -6,5 +8,20 @@ def add_encoding(xds, compressor, chunks=None):
 
     encoding = {}
     for da_name in list(xds.data_vars):
-        da_chunks = [chunks[dim_name] for dim_name in xds[da_name].sizes]
-        xds[da_name].encoding = {"compressor": compressor, "chunks": da_chunks}
+        if isinstance(xds[da_name].data, da.Array):
+            da_chunks = dict(xds[da_name].chunksizes)
+
+            # Loop over dimensions that can be chunked
+            for dim_name in chunks.keys():
+                # Only add user specified chunks to dimensions that aren't already chunked
+                # ie don't touch time on VISIBILITY when using `read_col_conversion_dask`
+                if len(da_chunks.get(dim_name, (1,))):
+                    da_chunks[dim_name] = chunks[dim_name]
+
+            xds[da_name].encoding = {"compressor": compressor, "chunks": da_chunks}
+
+        else:
+            for da_name in list(xds.data_vars):
+                da_chunks = [chunks[dim_name] for dim_name in xds[da_name].sizes]
+                xds[da_name].encoding = {"compressor": compressor, "chunks": da_chunks}
+

--- a/src/xradio/vis/_vis_utils/_zarr/encoding.py
+++ b/src/xradio/vis/_vis_utils/_zarr/encoding.py
@@ -6,9 +6,5 @@ def add_encoding(xds, compressor, chunks=None):
 
     encoding = {}
     for da_name in list(xds.data_vars):
-        if chunks:
-            da_chunks = [chunks[dim_name] for dim_name in xds[da_name].sizes]
-            xds[da_name].encoding = {"compressor": compressor, "chunks": da_chunks}
-            # print(xds[da_name].encoding)
-        else:
-            xds[da_name].encoding = {"compressor": compressor}
+        da_chunks = [chunks[dim_name] for dim_name in xds[da_name].sizes]
+        xds[da_name].encoding = {"compressor": compressor, "chunks": da_chunks}

--- a/src/xradio/vis/_vis_utils/_zarr/encoding.py
+++ b/src/xradio/vis/_vis_utils/_zarr/encoding.py
@@ -1,5 +1,6 @@
 import dask.array as da
 
+
 def add_encoding(xds, compressor, chunks=None):
     if chunks is None:
         chunks = xds.sizes
@@ -24,4 +25,3 @@ def add_encoding(xds, compressor, chunks=None):
             for da_name in list(xds.data_vars):
                 da_chunks = [chunks[dim_name] for dim_name in xds[da_name].sizes]
                 xds[da_name].encoding = {"compressor": compressor, "chunks": da_chunks}
-

--- a/src/xradio/vis/convert_msv2_to_processing_set.py
+++ b/src/xradio/vis/convert_msv2_to_processing_set.py
@@ -22,6 +22,8 @@ def convert_msv2_to_processing_set(
     storage_backend="zarr",
     parallel: bool = False,
     overwrite: bool = False,
+    lofar: bool = False,
+    lofar_read_size: int = 1024,
 ):
     """Convert a Measurement Set v2 into a Processing Set of Measurement Set v4.
 
@@ -48,6 +50,7 @@ def convert_msv2_to_processing_set(
         Whether to interpolate the time axis of the ephemeris data variables (of the field_and_source sub-dataset) to the time axis of the main dataset
     use_table_iter : bool, optional
         Whether to use the table iterator to read the main table of the MS v2. This should be set to True when reading datasets with large number of rows and few partitions, by default False.
+        This option is ignored when `lofar` set to True.
     compressor : numcodecs.abc.Codec, optional
         The Blosc compressor to use when saving the converted data to disk using Zarr, by default numcodecs.Zstd(level=2).
     storage_backend : {"zarr", "netcdf"}, optional
@@ -56,6 +59,11 @@ def convert_msv2_to_processing_set(
         Makes use of Dask to execute conversion in parallel, by default False.
     overwrite : bool, optional
         Whether to overwrite an existing processing set, by default False.
+    lofar : bool, optional
+        Choose whether to read column in "lofar" mode, False by default.
+        lofar mode allows larger than memory partitions to be converted. The method ignores the `main_chunksize`. Instead chunks only along the time dimension and can be controlled using the `lofar_read_size` option.
+    lofar_read_size : int, optional
+        The target number of MiB to read from the MSv2 and insert into a zarr chunk. Defaults to 1024 MiB.
     """
 
     partitions = create_partitions(in_file, partition_scheme=partition_scheme)
@@ -94,6 +102,8 @@ def convert_msv2_to_processing_set(
                     ephemeris_interpolate=ephemeris_interpolate,
                     compressor=compressor,
                     overwrite=overwrite,
+                    lofar=lofar,
+                    lofar_read_size=lofar_read_size,
                 )
             )
         else:
@@ -111,6 +121,8 @@ def convert_msv2_to_processing_set(
                 ephemeris_interpolate=ephemeris_interpolate,
                 compressor=compressor,
                 overwrite=overwrite,
+                lofar=lofar,
+                lofar_read_size=lofar_read_size,
             )
 
     if parallel:


### PR DESCRIPTION
Adds a new method `read_col_conversion_dask` that allows larger than memory columns to be converted. Various changes:

1. xarray DataSet encoding has been cleaned up and adjusted to ignore DataArrays that are dask arrays
2. `lofar` and `lofar_read_size` arguments added to `convert_msv2_to_processing_set`
3. TableManager class has been added so that multi-thread/process conversion can happen without having to serialize casacore table objects. This replaces `open_table_ro` and `open_query` in `convert_and_write_partition`
4. `read_col_conversion_dask` uses dask's map_blocks to create tasks for each chunk of a DataArray which reads data from a MSv2 column and reshapes it

This has been used to convert 9TB of lofar data in ~4.5 hours which was previously impossible unless a compute node with >9TB of memory is used