### PR TITLE
Processing set name formatting

### DIFF
--- a/src/xradio/vis/_vis_utils/_ms/conversion.py
+++ b/src/xradio/vis/_vis_utils/_ms/conversion.py
@@ -662,7 +662,7 @@ def create_taql_query(partition_info):
 def convert_and_write_partition(
     in_file: str,
     out_file: str,
-    ms_v4_id: int,
+    ms_v4_id: Union[int, str],
     partition_info: Dict,
     use_table_iter: bool,
     partition_scheme: str = "ddi_intent_field",

--- a/src/xradio/vis/convert_msv2_to_processing_set.py
+++ b/src/xradio/vis/convert_msv2_to_processing_set.py
@@ -78,6 +78,8 @@ def convert_msv2_to_processing_set(
             + str(partition_info["SCAN_NUMBER"])
         )
 
+        # prepend '0' to ms_v4_id as needed
+        ms_v4_id = f'{ms_v4_id:0>{len(str(len(partitions) - 1))}}'
         if parallel:
             delayed_list.append(
                 dask.delayed(convert_and_write_partition)(

--- a/src/xradio/vis/convert_msv2_to_processing_set.py
+++ b/src/xradio/vis/convert_msv2_to_processing_set.py
@@ -79,7 +79,7 @@ def convert_msv2_to_processing_set(
         )
 
         # prepend '0' to ms_v4_id as needed
-        ms_v4_id = f'{ms_v4_id:0>{len(str(len(partitions) - 1))}}'
+        ms_v4_id = f"{ms_v4_id:0>{len(str(len(partitions) - 1))}}"
         if parallel:
             delayed_list.append(
                 dask.delayed(convert_and_write_partition)(


### PR DESCRIPTION
This commit aligns number of digit for ms_v4_id.
If number of partitions is 11, for example, name of the msv4 will change from "ps_name_0" to "ps_name_00", etc.
That affects sort order of the msv4 on disk. Previously, it was like the following.

```
ps_name_0
ps_name_1
ps_name_10
ps_name_2
...
ps_name_9
```

After this change, the order will be more intuitive.

```
ps_name_00
ps_name_01
ps_name_02
...
ps_name_09
ps_name_10
```