### PR TITLE
Datatree prototyping

### DIFF
--- a/src/xradio/datatree/__init__.py
+++ b/src/xradio/datatree/__init__.py
@@ -1,1 +1,2 @@
 from xradio.datatree.datatree_builder import DatatreeBuilder
+import xradio.datatree.datatree_accessor  # noqa

--- a/src/xradio/datatree/__init__.py
+++ b/src/xradio/datatree/__init__.py
@@ -1,0 +1,1 @@
+from xradio.datatree.datatree_builder import DatatreeBuilder

--- a/src/xradio/datatree/datatree_accessor.py
+++ b/src/xradio/datatree/datatree_accessor.py
@@ -10,6 +10,11 @@ class InvalidAccessorLocation(ValueError):
   pass
 
 
+VISIBILITY_DATASET_TYPES = {"visibility", "spectrum", "wvr"}
+SECONDARY_DATASET_TYPES = {"antenna", "field_and_source", "gain_curve", "system_calibration", "weather"}
+DATASET_TYPES = VISIBILITY_DATASET_TYPES | SECONDARY_DATASET_TYPES
+
+
 @xarray.register_datatree_accessor("msa")
 class MeasurementSetAccessor:
   _dt: DataTree
@@ -104,7 +109,7 @@ class MeasurementSetAccessor:
   @property
   def antenna(self) -> DataTree:
     """ Access the antenna dataset """
-    if self._dt.attrs.get("type") not in {"visibility", "spectrum", "wvr"}:
+    if self._dt.attrs.get("type") not in VISIBILITY_DATASET_TYPES:
       raise InvalidAccessorLocation(
         f"{self._dt.path} is not a visibility node. "
         f"There is no antenna dataset connected with it.")

--- a/src/xradio/datatree/datatree_accessor.py
+++ b/src/xradio/datatree/datatree_accessor.py
@@ -1,0 +1,127 @@
+import xarray
+from xarray import DataTree
+
+from xradio.datatree.datatree_builder import VALID_OPTIONS
+
+class DatasetNotFound(ValueError):
+  pass
+
+class InvalidAccessorLocation(ValueError):
+  pass
+
+
+@xarray.register_datatree_accessor("msa")
+class MeasurementSetAccessor:
+  _dt: DataTree
+  _option: float
+  _remove_suffix: bool
+
+  def __init__(self, datatree: DataTree):
+    self._dt = datatree
+    root = self._dt.root
+    try:
+      option = float(root.attrs["__datatree_proposal_option__"])
+    except (KeyError, ValueError):
+      option = 1.0
+
+    if option not in VALID_OPTIONS:
+      raise ValueError(f"{option} is not a valid DataTree Proposal option {VALID_OPTIONS}")
+
+    self._option = option
+
+    try:
+      remove_suffix = bool(root.attrs["__datatree_proposal_remove_suffix__"])
+    except (KeyError, ValueError):
+      remove_suffix = False
+
+    self._remove_suffix = remove_suffix
+
+  def _maybe_rename_dataset(self, dataset: str) -> str:
+    return dataset.replace("_xds", "") if self._remove_suffix else dataset
+
+  @property
+  def option(self) -> float:
+    """ DataTree proposal option getter """
+    return self._option
+
+  @option.setter
+  def option(self, value: float) -> None:
+    """ DataTree proposal option setter """
+    if value not in VALID_OPTIONS:
+      raise ValueError(f"{value} is not a valid DataTree Proposal option {VALID_OPTIONS}")
+
+    self._option = value
+
+  def _get_optional_dataset(self, dataset: str) -> DataTree | None:
+    name = self._maybe_rename_dataset(dataset)
+
+    if self._dt.attrs.get("type") not in {"visibility", "spectrum", "wvr"}:
+      raise InvalidAccessorLocation(
+        f"{self._dt.path} is not a visibility node. "
+        f"There is no {name} dataset associated with it.")
+
+    try:
+      if self._option == 1.0:
+        other_ds = self._dt.siblings[name]
+      elif self._option == 2.0:
+        other_ds = self._dt.children[name]
+      elif self._option == 2.5:
+        other_ds = self._dt.children[name]
+      elif self._option == 3.0:
+        partition_str = self._dt.path.split("/")[-1]
+        partition = int(partition_str[len("xds"):])
+        other_ds = self._dt.root[f"/{name}/xds{partition}"]
+      else:
+        raise ValueError(f"Invalid option {self._option}")
+    except KeyError as e:
+      return None
+
+    return other_ds
+
+  def field_and_source(self, data_group_name="base") -> DataTree | None:
+    return self._get_optional_dataset(f"field_and_source_xds_{data_group_name}")
+
+  @property
+  def gain_curve(self) -> DataTree | None:
+    return self._get_optional_dataset("gain_curve_xds")
+
+  @property
+  def phase_calibration(self) -> DataTree | None:
+    return self._get_optional_dataset("phase_calibration_xds")
+
+  @property
+  def system_calibration(self) -> DataTree | None:
+    return self._get_optional_dataset("system_calibration_xds")
+
+  @property
+  def weather(self) -> DataTree | None:
+    return self._get_optional_dataset("weather_xds")
+
+  @property
+  def antenna(self) -> DataTree:
+    """ Access the antenna dataset """
+    if self._dt.attrs.get("type") not in {"visibility", "spectrum", "wvr"}:
+      raise InvalidAccessorLocation(
+        f"{self._dt.path} is not a visibility node. "
+        f"There is no antenna dataset connected with it.")
+
+    name = self._maybe_rename_dataset("antenna_xds")
+
+    try:
+      if self._option == 1.0:
+        antenna_ds = self._dt.siblings[name]
+      elif self._option == 2.0:
+        antenna_ds = self._dt.children[name]
+      elif self._option == 2.5:
+        antenna_ds = self._dt.root[name]
+      elif self._option == 3.0:
+        partition_str = self._dt.path.split("/")[-1]
+        partition = int(partition_str[len("xds"):])
+        antenna_ds = self._dt.root[f"/{name}/xds{partition}"]
+      else:
+        raise ValueError(f"Invalid option {self._option}")
+    except KeyError as e:
+      raise DatasetNotFound(f"No antenna dataset found relative to {self._dt.path}") from e
+
+    return antenna_ds
+

--- a/src/xradio/datatree/datatree_accessor.py
+++ b/src/xradio/datatree/datatree_accessor.py
@@ -107,7 +107,7 @@ class MeasurementSetAccessor:
     return self._get_optional_dataset("weather_xds")
 
   @property
-  def antenna(self) -> DataTree:
+  def antennas(self) -> DataTree:
     """ Access the antenna dataset """
     if self._dt.attrs.get("type") not in VISIBILITY_DATASET_TYPES:
       raise InvalidAccessorLocation(

--- a/src/xradio/datatree/datatree_accessor.py
+++ b/src/xradio/datatree/datatree_accessor.py
@@ -19,6 +19,10 @@ class MeasurementSetAccessor:
   def __init__(self, datatree: DataTree):
     self._dt = datatree
     root = self._dt.root
+
+    # option and remove_suffix would be unnecessary in a complete solution
+    # but are used here to delegate based on the different prototype options
+    # and configurations
     try:
       option = float(root.attrs["__datatree_proposal_option__"])
     except (KeyError, ValueError):

--- a/src/xradio/datatree/datatree_builder.py
+++ b/src/xradio/datatree/datatree_builder.py
@@ -194,6 +194,9 @@ class DatatreeBuilder:
     else:
       root = zarr.open_group(store=destination_root, mode="w-")
 
+    root.attrs["__datatree_proposal_option__"] = self._option
+    root.attrs["__datatree_proposal_remove_suffix__"] = self._remove_suffix
+
     # Create zarr partition groups below the root
     for p, (partition, datasets) in enumerate(partition_datasets.items(), 1):
       # Create root children

--- a/src/xradio/datatree/datatree_builder.py
+++ b/src/xradio/datatree/datatree_builder.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+from collections import defaultdict
+import importlib
+import importlib.metadata
+import os.path
+from packaging.version import Version
+import shutil
+from typing import Dict, List, Literal, Set, Tuple
+import warnings
+
+import zarr
+
+# Files that are associated with zarr versions
+ZARR_FILE_VERSION: Dict[str, int] = {
+  ".zgroup": 2,
+  "zarr.json": 3,
+}
+
+# https://confluence.skatelescope.org/display/SEC/Datatree+proposal
+VALID_OPTIONS: Set[float] = {
+  1.0,
+  2.0,
+  2.5,
+  3.0
+}
+
+class DatatreeBuilder:
+  """Builds a Datatree representation from an existing Processing Set representation"""
+
+  """Processing Set url"""
+  _url: str
+  """Datatree proposal option https://confluence.skatelescope.org/display/SEC/Datatree+proposal"""
+  _option: float
+  """Datatree url"""
+  _destination_url: str
+  """Configures overwiting of existing data at the Datatree url"""
+  _overwrite: bool
+  """Configures copying or moving data from the Processing Set"""
+  _copy: bool
+  """Configures removal of the xds suffix from Processing Set datasets"""
+  _remove_suffix: bool
+  """Configures the location of the zarr metadata consolidation at either
+  the Datatree root or the at the partition level"""
+  _consolidate_at: Literal["root", "partition"]
+
+  def __init__(self):
+    self._url = ""
+    self._copy = True
+    self._destination_url = ""
+    self._overwrite = True
+    self._option = 2.0
+    self._consolidate_at = "partition"
+    self._remove_suffix = False
+
+  def with_url(self, url: str) -> DatatreeBuilder:
+    """ Sets the input url """
+    self._url = url.rstrip(os.path.sep)
+    return self
+
+  def with_copy(self) -> DatatreeBuilder:
+    """ Configures copying of data from the Processing Set to the DataTree.
+    If False, data will be moved """
+    self._copy = True
+    return self
+
+  def with_move(self) -> DatatreeBuilder:
+    """ Configures moving of Processing Set data to the DataTree"""
+    self._copy = False
+    return self
+
+  def with_remove_suffix(self) -> DatatreeBuilder:
+    """ Configures removal of xds suffix from dataset name """
+    self._remove_suffix = True
+    return self
+
+  def with_option(self, option: float = 2.5) -> DatatreeBuilder:
+    self._option = option
+    return self
+
+  def with_destination(self, destination_url: str) -> DatatreeBuilder:
+    """ Sets the destination url of the DataTree """
+    self._destination_url = destination_url
+    return self
+
+  def with_overwrite(self, overwrite: bool = True) -> DatatreeBuilder:
+    """ Configures overwriting any existing data in the destination url"""
+    self._overwrite = overwrite
+    return self
+
+  def with_consolidate_at(self, at: str) -> DatatreeBuilder:
+    assert at in {"root", "partition"}
+    self._consolidate_at = at
+    return self
+
+  def maybe_generate_destination_url(self) -> str:
+    """ Returns destination url if populated, else generates one from the input url"""
+    if self._destination_url:
+      if not self._destination_url.endswith(".zarr"):
+        warnings.warn(
+          f"{self._destination_url} does not have a .zarr extension "
+          f"and will not be automatically recognised by xarray as a zarr store.\n"
+          f"The engine will need to be explicitly specified via "
+          f"xarray.open_datatree({self._destination_url}, engine='zarr')")
+
+      return self._destination_url
+
+    root, base_url = os.path.split(self._url)
+    # The xarray zarr engine is engaged if a .zarr extension is encountered
+    # https://github.com/pydata/xarray/blob/1189240b2631fa27dec0cbea76bf3cf977b42fce/xarray/backends/zarr.py#L1527-L1535
+    # Strip off non standard extensions and replace with .zarr
+    name, _ = os.path.splitext(base_url)
+    return os.path.join(root, f"{name}_datatree.zarr")
+
+  def maybe_rename_dataset(self, name: str) -> str:
+    """ Returns a possibly renamed dataset name if xds suffix removal is configured,
+     otherwise the original name """
+    return name.replace("_xds", "") if self._remove_suffix else name
+
+  @property
+  def strategy_string(self) -> str:
+    """ Returns a human readable string describing the Datatree build strategy"""
+    bits = ["Datatree Build Strategy"]
+    tab = " " * 2
+    bits.append(f"{tab}* Datatree proposal option:'{self._option}'")
+    bits.append(f"{tab}* Data in '{self._url}' will be {'copied' if self._copy else 'moved'} to")
+    bits.append(f"{tab}  '{self.maybe_generate_destination_url()}'")
+    if self._overwrite:
+      bits.append(f"{tab}* '{self.maybe_generate_destination_url()}' will be overwritten")
+
+    if self._consolidate_at == "root":
+      bits.append(f"{tab}* Metadata will be consolidated at the Datatree root")
+    elif self._consolidate_at == "partition":
+      bits.append(f"{tab}* Metadata will be consolidated at the Partition level, below the DataTree root")
+
+    if self._remove_suffix:
+      bits.append(f"{tab}* 'xds' will be removed from dataset names")
+
+    return "\n".join(bits)
+
+  def build(self):
+    """ Build the Datatree from the configured input """
+    if self._option not in VALID_OPTIONS:
+      raise ValueError(f"{self._option} is a valid datatree struture option {VALID_OPTIONS}")
+
+    if not self._url or not os.path.exists(self._url) or not os.path.isdir(self._url):
+      raise FileNotFoundError(f"{self._url} does not exist or is not a directory")
+
+    # Find non-hidden directories
+    with os.scandir(self._url) as it:
+      partitions = [e.name for e in it if e.is_dir() and not e.name.startswith(".")]
+
+    if len(partitions) == 0:
+      raise FileNotFoundError(f"{self._url} does not contain any partitions")
+
+    # Iterate through the partitions, finding datasets and
+    # inferring their associated zarr versions
+    partition_datasets: Dict[str, List[Tuple[str, int]]] = defaultdict(list)
+
+    for partition in partitions:
+      partition_dir = os.path.join(self._url, partition)
+      with os.scandir(partition_dir) as it:
+        for dataset_dir in [e.name for e in it if e.is_dir()]:
+          with os.scandir(os.path.join(partition_dir, dataset_dir)) as it:
+            zarr_files = {e.name for e in it if e.is_file() and e.name in ZARR_FILE_VERSION}
+            zarr_versions = {ZARR_FILE_VERSION[f] for f in zarr_files}
+
+            if len(zarr_versions) == 0:
+              continue
+            elif len(zarr_versions) > 1:
+              raise ValueError(
+                f"Multiple zarr versions {zarr_versions} "
+                f"found in {os.path.join(partition_dir, dataset_dir)}"
+              )
+            elif next(iter(zarr_versions)) != 2:
+              raise NotImplementedError(f"Conversion of Zarr v{zarr_version} Datasets")
+
+            partition_datasets[partition].append((dataset_dir, next(iter(zarr_versions))))
+
+    zarr_library_version = Version(importlib.metadata.version("zarr"))
+
+    if zarr_library_version >= Version("3.0.0"):
+      raise ValueError(f"zarr version {zarr_library_version} >= 3.0.0")
+
+    # Create root zarr group
+    # This code is probably specific to zarr versions < 3.
+    # For zarr >= 3, zarr.create_group looks to be appropriate.
+    destination_root = self.maybe_generate_destination_url()
+
+    if self._overwrite:
+      shutil.rmtree(destination_root, ignore_errors=True)
+      os.makedirs(destination_root, exist_ok=False)
+      root = zarr.open_group(store=destination_root, mode="w")
+    else:
+      root = zarr.open_group(store=destination_root, mode="w-")
+
+    # Create zarr partition groups below the root
+    for p, (partition, datasets) in enumerate(partition_datasets.items(), 1):
+      # Create root children
+      if self._option in {1.0, 2.0, 2.5}:
+        # Partition is a child of the tree root
+        root.create_group(partition)
+      elif self._option == 3.0 and p == 1:
+        # Partition is a child of the table type, which
+        # in turn is a child of the tree root
+        # Assumption: Each partition has the same datasets.
+        # Good enough for a prototype
+        for dataset, _ in datasets:
+          root.create_group(self.maybe_rename_dataset(dataset))
+
+      # Copy/move datasets into the appropriate locations
+      for dataset, zarr_version in datasets:
+        source = os.path.join(self._url, partition, dataset)
+        dest_dataset = self.maybe_rename_dataset(dataset)
+
+        if self._option == 1.0:
+          dest = os.path.join(destination_root, partition, dest_dataset)
+        elif self._option == 2.0:
+          if dataset == "correlated_xds":
+            # Visibility dataset forms the root of the partition
+            dest = os.path.join(destination_root, partition)
+          else:
+            # Other datasets are children of the visibility dataset
+            dest = os.path.join(destination_root, partition, dest_dataset)
+        elif self._option == 2.5:
+          if dataset == "correlated_xds":
+            # Visibility dataset forms the root of the partition
+            dest = os.path.join(destination_root, partition)
+          elif dataset == "antenna_xds":
+            # The antenna dataset is a child of the tree root
+            # For prototyping purposes, we only write it once
+            dest = os.path.join(destination_root, dest_dataset)
+            if os.path.exists(dest):
+              continue
+          else:
+            # Other datasets are children of the visibility dataset
+            dest = os.path.join(destination_root, partition, dest_dataset)
+        elif self._option == 3.0:
+          dest = os.path.join(destination_root, dest_dataset, f"xds{p}")
+        else:
+          raise NotImplementedError(f"Datatree proposal option {self._option}")
+
+        # Perform the copy or move
+        if self._copy:
+          shutil.copytree(source, dest, dirs_exist_ok=True)
+        else:
+          shutil.rmtree(dest, ignore_errors=True)
+          shutil.move(source, dest)
+
+      # Consolidate metadata at the partition level
+      if self._consolidate_at == "partition":
+        if self._option in {1.0, 2.0, 2.5}:
+          zarr.consolidate_metadata(os.path.join(destination_root, partition))
+        elif self._option == 3.0 and p == len(partition_datasets):
+          # Consolidate after the last partition has been created
+          for dataset, _ in datasets:
+            dest_dataset = self.maybe_rename_dataset(dataset)
+            zarr.consolidate_metadata(os.path.join(destination_root, dest_dataset))
+
+    if self._consolidate_at == "root":
+      zarr.consolidate_metadata(destination_root)

--- a/src/xradio/datatree/datatree_builder.py
+++ b/src/xradio/datatree/datatree_builder.py
@@ -44,19 +44,14 @@ class DatatreeBuilder:
   the Datatree root or the at the partition level"""
   _consolidate_at: Literal["root", "partition"]
 
-  def __init__(self):
-    self._url = ""
+  def __init__(self, url: str):
+    self._url = url
     self._copy = True
     self._destination_url = ""
     self._overwrite = True
     self._option = 2.0
     self._consolidate_at = "partition"
     self._remove_suffix = False
-
-  def with_url(self, url: str) -> DatatreeBuilder:
-    """ Sets the input url """
-    self._url = url.rstrip(os.path.sep)
-    return self
 
   def with_copy(self) -> DatatreeBuilder:
     """ Configures copying of data from the Processing Set to the DataTree.

--- a/src/xradio/datatree/dt_convert.py
+++ b/src/xradio/datatree/dt_convert.py
@@ -4,7 +4,7 @@ import logging
 
 from xradio.datatree.datatree_builder import DatatreeBuilder
 import xradio.datatree.datatree_accessor  # noqa
-from xradio.datatree.datatree_accessor import InvalidAccessorLocation
+from xradio.datatree.datatree_accessor import InvalidAccessorLocation, VISIBILITY_DATASET_TYPES, DATASET_TYPES
 
 from xarray import DataTree
 import pytest
@@ -28,10 +28,6 @@ def assert_raises(expected_exception):
 
 
 PROPOSAL_URL = "https://confluence.skatelescope.org/display/SEC/Datatree+proposal"
-
-VISIBILITY_DATASET_TYPES = {"visibility", "spectrum", "wvr"}
-SECONDARY_DATASET_TYPES = {"antenna", "field_and_source", "gain_curve", "system_calibration", "weather"}
-DATASET_TYPES = VISIBILITY_DATASET_TYPES | SECONDARY_DATASET_TYPES
 
 def create_parser():
   p = argparse.ArgumentParser()

--- a/src/xradio/datatree/dt_convert.py
+++ b/src/xradio/datatree/dt_convert.py
@@ -8,7 +8,8 @@ PROPOSAL_URL = "https://confluence.skatelescope.org/display/SEC/Datatree+proposa
 def create_parser():
   p = argparse.ArgumentParser()
   p.add_argument("ps", help="Processing Set")
-  p.add_argument("-m", "--move")
+  p.add_argument("-m", "--move",
+                 help="Moves Processing Set Datasets instead of copying them")
   p.add_argument("-o", "--option",
                  help=f"Datatree proposal option as described at {PROPOSAL_URL}",
                  default=1.0,
@@ -30,7 +31,7 @@ def create_parser():
 
 if __name__ == "__main__":
   args = create_parser().parse_args()
-  logging.basicConfig(format="%(levelname)s %(message)s", level=logging.DEBUG)
+  logging.basicConfig(format="%(levelname)s %(message)s", level=logging.INFO)
   builder = DatatreeBuilder()
   builder = builder.with_url(args.ps)
   builder = builder.with_option(args.option)

--- a/src/xradio/datatree/dt_convert.py
+++ b/src/xradio/datatree/dt_convert.py
@@ -52,8 +52,7 @@ def create_parser():
 if __name__ == "__main__":
   args = create_parser().parse_args()
   logging.basicConfig(format="%(levelname)s %(message)s", level=logging.INFO)
-  builder = DatatreeBuilder()
-  builder = builder.with_url(args.ps)
+  builder = DatatreeBuilder(args.ps)
   builder = builder.with_option(args.option)
   builder = builder.with_consolidate_at(args.consolidate_at)
   builder = builder.with_destination(args.output)

--- a/src/xradio/datatree/dt_convert.py
+++ b/src/xradio/datatree/dt_convert.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
     # Perform basic filtering and accessor testing
     for node in dt.filter(pass_filter).subtree:
       if node.attrs.get("type") in VISIBILITY_DATASET_TYPES:
-        assert node.msa.antenna.attrs["type"] == "antenna"
+        assert node.msa.antennas.attrs["type"] == "antenna"
         if weather := node.msa.weather:
            assert weather.attrs["type"] == "weather"
         if gain_curve := node.msa.gain_curve:
@@ -96,7 +96,7 @@ if __name__ == "__main__":
           node.msa.weather
 
         with assert_raises(InvalidAccessorLocation):
-          node.msa.antenna
+          node.msa.antennas
 
     if args.test == "read":
 

--- a/src/xradio/datatree/dt_convert.py
+++ b/src/xradio/datatree/dt_convert.py
@@ -1,0 +1,54 @@
+import argparse
+import logging
+
+from xradio.datatree.datatree_builder import DatatreeBuilder
+
+PROPOSAL_URL = "https://confluence.skatelescope.org/display/SEC/Datatree+proposal"
+
+def create_parser():
+  p = argparse.ArgumentParser()
+  p.add_argument("ps", help="Processing Set")
+  p.add_argument("-m", "--move")
+  p.add_argument("-o", "--option",
+                 help=f"Datatree proposal option as described at {PROPOSAL_URL}",
+                 default=1.0,
+                 type=float)
+  p.add_argument("-rs", "--remove-suffix",
+                 help="Removes xds from dataset name",
+                 action="store_true")
+  p.add_argument("-c", "--consolidate-at",
+                 default="root",
+                 choices=["root", "partition"])
+  p.add_argument("-ol", "--output",
+                 help=(
+                      "Output location. If empty, will be generated "
+                      "from the processing set name."
+                 ),
+                 default="")
+  p.add_argument("--test", choices=["none", "open", "read"], default="open")
+  return p
+
+if __name__ == "__main__":
+  args = create_parser().parse_args()
+  logging.basicConfig(format="%(levelname)s %(message)s", level=logging.DEBUG)
+  builder = DatatreeBuilder()
+  builder = builder.with_url(args.ps)
+  builder = builder.with_option(args.option)
+  builder = builder.with_consolidate_at(args.consolidate_at)
+  builder = builder.with_destination(args.output)
+  builder = builder.with_overwrite(True)
+  if args.move:
+    builder = builder.with_move()
+  if args.remove_suffix:
+    builder = builder.with_remove_suffix()
+
+  print(builder.strategy_string)
+  builder.build()
+
+  print(f"dt = xarray.open_datatree(\"{builder.maybe_generate_destination_url()}\", engine=\"zarr\")")
+
+  if args.test in {"open", "read"}:
+    import xarray
+    dt = xarray.open_datatree(builder.maybe_generate_destination_url())
+    if args.test == "read":
+      dt.load()

--- a/src/xradio/datatree/dt_convert.py
+++ b/src/xradio/datatree/dt_convert.py
@@ -6,10 +6,6 @@ from xradio.datatree.datatree_builder import DatatreeBuilder
 import xradio.datatree.datatree_accessor  # noqa
 from xradio.datatree.datatree_accessor import InvalidAccessorLocation, VISIBILITY_DATASET_TYPES, DATASET_TYPES
 
-from xarray import DataTree
-import pytest
-
-
 
 @contextlib.contextmanager
 def assert_raises(expected_exception):
@@ -74,6 +70,8 @@ if __name__ == "__main__":
 
   if args.test in {"open", "read"}:
     import xarray
+    from xarray import DataTree
+
     dt = xarray.open_datatree(builder.maybe_generate_destination_url())
 
     def pass_filter(node: DataTree) -> bool:


### PR DESCRIPTION
- Prototypes #350 

This draft PR contains a script that re-arranges a Processing Set to produce a Datatree corresponding to the options present in this document:

- https://confluence.skatelescope.org/display/SEC/Datatree+proposal

Invoke the script with

```
$ python src/xradio/datatree/dt_convert.py ~/data/VLBA_TL016B_split_lsrk.vis.zarr
```

There are multiple options to configure the resulting Datatree, call the script with `--help` to discover them.

This PR has only been tested with the `VLBA_TL016B_split_lsrk` dataset.

~~Accessors are still TODO, but it might be useful to start getting a feel for the layout.~~ Accessors have been implemented for the various options

/cc @Jan-Willem @scpmw 