### PR TITLE
Read col conversion dask improvements

### DIFF
--- a/src/xradio/measurement_set/_utils/_msv2/_tables/read.py
+++ b/src/xradio/measurement_set/_utils/_msv2/_tables/read.py
@@ -1434,9 +1434,8 @@ def load_col_chunk(
     slc = slice(start_row, end_row)
     tidxs_slc = tidxs[slc]
 
-    tidxs_slc = (
-        tidxs_slc - tidxs_slc[0]
-    )  # Indices of reshaped_data along time differ from values in tidxs. Assumes first time is earliest time
+    # Indices of reshaped_data along time differ from values in tidxs. Assumes first time is earliest time
+    tidxs_slc = tidxs_slc - tidxs_slc[0]
     bidxs_slc = bidxs[slc]
 
     # Populate `reshaped_data` with `row_data`

--- a/src/xradio/measurement_set/_utils/_msv2/msv2_to_msv4_meta.py
+++ b/src/xradio/measurement_set/_utils/_msv2/msv2_to_msv4_meta.py
@@ -13,6 +13,16 @@ col_to_data_variable_names = {
     "TIME_CENTROID": "TIME_CENTROID",
     "EXPOSURE": "EFFECTIVE_INTEGRATION_TIME",
 }
+# List of columns that read_col_conversion_dask() should be used on.
+# Other columns are processed faster when using read_col_conversion_numpy()
+time_parallel_columns = [
+    "DATA",
+    "CORRECTED_DATA",
+    "MODEL_DATA",
+    "WEIGHT_SPECTRUM",
+    "WEIGHT",
+    "FLAG",
+]
 col_dims = {
     "DATA": ("time", "baseline_id", "frequency", "polarization"),
     "CORRECTED_DATA": ("time", "baseline_id", "frequency", "polarization"),


### PR DESCRIPTION
Small changes so that `read_col_conversion_dask()` is more robust.

Changes:
- `np.tile()` --> `dask.array.tile()`. This ensures WEIGHT and WEIGHT_SPECTRUM columns aren't eagerly computed eagerly, reducing memory usage. Note: `dask.array.tile()` adds each tile as a separate chunk so rechunking is required inside `get_weight()`.
- `time_parallel_columns` variable so only large columns with a frequency axis are read and reshaped by `read_col_conversion_dask()`, other columns are sufficiently small to fit in memory. Performance is better using `read_col_conversion_numpy()`.