### PR TITLE
read_col_conversion fixes

### DIFF
--- a/src/xradio/measurement_set/_utils/_msv2/conversion.py
+++ b/src/xradio/measurement_set/_utils/_msv2/conversion.py
@@ -627,6 +627,7 @@ def create_data_variables(
 
     while target_cols:
         col = target_cols.popleft()
+        datavar_name = col_to_data_variable_names[col]
         try:
             start = time.time()
             if col == "WEIGHT":
@@ -653,12 +654,12 @@ def create_data_variables(
                 if col == "TIME_CENTROID":
                     col_data = convert_casacore_time(col_data, False)
 
-                xds[col_to_data_variable_names[col]] = xr.DataArray(
+                xds[datavar_name] = xr.DataArray(
                     col_data,
                     dims=col_dims[col],
                 )
 
-            xds[col_to_data_variable_names[col]].attrs.update(
+            xds[datavar_name].attrs.update(
                 create_attribute_metadata(col, main_column_descriptions)
             )
             logger.debug(

--- a/src/xradio/measurement_set/_utils/_msv2/conversion.py
+++ b/src/xradio/measurement_set/_utils/_msv2/conversion.py
@@ -641,16 +641,22 @@ def create_data_variables(
                 col_data = convert_casacore_time(col_data, False)
 
             elif col == "WEIGHT":
-                col_data = da.tile(
-                    col_data[:, :, None, :],
-                    (1, 1, xds.sizes["frequency"], 1),
-                )
-                # da.tile() adds each repeat as a separate chunk, so rechunking is necessary
-                chunksizes = tuple(
-                    main_chunksize.get(dim, xds.sizes[dim])
-                    for dim in ("time", "baseline_id", "frequency", "polarization")
-                )
-                col_data = col_data.rechunk(chunksizes)
+                if parallel_mode == "time":
+                    col_data = da.tile(
+                        col_data[:, :, None, :],
+                        (1, 1, xds.sizes["frequency"], 1),
+                    )
+                    # da.tile() adds each repeat as a separate chunk, so rechunking is necessary
+                    chunksizes = tuple(
+                        main_chunksize.get(dim, xds.sizes[dim])
+                        for dim in ("time", "baseline_id", "frequency", "polarization")
+                    )
+                    col_data = col_data.rechunk(chunksizes)
+                else:
+                    col_data = np.tile(
+                        col_data[:, :, None, :],
+                        (1, 1, xds.sizes["frequency"], 1),
+                    ) 
 
             xds[datavar_name] = xr.DataArray(
                 col_data,

--- a/src/xradio/measurement_set/_utils/_msv2/conversion.py
+++ b/src/xradio/measurement_set/_utils/_msv2/conversion.py
@@ -611,15 +611,15 @@ def create_data_variables(
     with table_manager.get_table() as tb_tool:
         col_names = tb_tool.colnames()
 
-    valid_col_names = set(col_names) & set(col_to_data_variable_names.keys())
-    if valid_col_names.issuperset({"WEIGHT", "WEIGHT_SPECTRUM"}):
-        valid_col_names.remove("WEIGHT")
+    col_names = set(col_names) & set(col_to_data_variable_names.keys())
+    if col_names.issuperset({"WEIGHT", "WEIGHT_SPECTRUM"}):
+        col_names.remove("WEIGHT")
 
-    logger.debug(f"The following columns will be converted: {sorted(valid_col_names)}")
+    logger.debug(f"The following columns will be converted: {sorted(col_names)}")
 
     main_table_attrs = extract_table_attributes(in_file)
     main_column_descriptions = main_table_attrs["column_descriptions"]
-    for col in valid_col_names:
+    for col in col_names:
         try:
             start = time.time()
             if col == "WEIGHT":
@@ -664,7 +664,7 @@ def create_data_variables(
             logger.debug(traceback.format_exc())
 
             if ("WEIGHT_SPECTRUM" == col) and (
-                "WEIGHT" in valid_col_names
+                "WEIGHT" in col_names
             ):  # Bogus WEIGHT_SPECTRUM column, need to use WEIGHT.
                 xds = get_weight(
                     xds,

--- a/src/xradio/measurement_set/_utils/_msv2/conversion.py
+++ b/src/xradio/measurement_set/_utils/_msv2/conversion.py
@@ -602,10 +602,10 @@ def create_data_variables(
     # TODO: To make this compatible with multi-node conversion, `read_col_conversion_dask` and TableManager must be pickled.
     # Casacore will make this difficult
     global read_col_conversion
-    if parallel_mode == "time":
-        read_col_conversion = read_col_conversion_dask
-    else:
-        read_col_conversion = read_col_conversion_numpy
+    read_col_conversion = (
+        read_col_conversion_dask if parallel_mode == "time"
+        else read_col_conversion_numpy
+    )
 
     # Create Data Variables
     with table_manager.get_table() as tb_tool:

--- a/src/xradio/measurement_set/_utils/_msv2/conversion.py
+++ b/src/xradio/measurement_set/_utils/_msv2/conversion.py
@@ -586,17 +586,13 @@ def create_data_variables(
     parallel_mode,
     main_chunksize,
 ):
-    # Get time chunks
-    time_chunksize = None
-    if parallel_mode == "time":
-        try:
-            time_chunksize = main_chunksize["time"]
-        except KeyError:
-            # If time isn't chunked then `read_col_conversion_dask` is slower than `read_col_conversion_numpy`
-            logger.warning(
-                "'time' isn't specified in `main_chunksize`. Defaulting to `parallel_mode = 'none'`."
-            )
-            parallel_mode = "none"
+    if parallel_mode == "time" and "time" not in main_chunksize:
+        logger.warning(
+            "'time' isn't specified in `main_chunksize`. Defaulting to `parallel_mode = 'none'`."
+        )
+        parallel_mode = "none"
+
+    time_chunksize = main_chunksize.get("time", None)
 
     # Create Data Variables
     with table_manager.get_table() as tb_tool:

--- a/src/xradio/measurement_set/_utils/_msv2/conversion.py
+++ b/src/xradio/measurement_set/_utils/_msv2/conversion.py
@@ -637,7 +637,7 @@ def create_data_variables(
             xds[datavar_name] = xr.DataArray(
                 col_data,
                 dims=col_dims[col],
-                attrs=create_attribute_metadata(col, main_column_descriptions)
+                attrs=create_attribute_metadata(col, main_column_descriptions),
             )
             logger.debug(f"Time to read column {col} : {time.time() - start}")
 
@@ -667,7 +667,8 @@ def get_read_col_conversion_function(col_name: str, parallel_mode: str) -> Calla
         "FLAG",
     }
     return (
-        read_col_conversion_dask if parallel_mode == "time" and col_name in large_columns
+        read_col_conversion_dask
+        if parallel_mode == "time" and col_name in large_columns
         else read_col_conversion_numpy
     )
 
@@ -676,7 +677,7 @@ def repeat_weight_array(
     weight_arr,
     parallel_mode: str,
     main_sizes: dict[str, int],
-    main_chunksize: dict[str, int]
+    main_chunksize: dict[str, int],
 ):
     """
     Repeat the weights read from the WEIGHT column along the frequency dimension.
@@ -695,7 +696,6 @@ def repeat_weight_array(
         return result.rechunk(chunksizes)
 
     return np.tile(reshaped_arr, repeats)
-
 
 
 def add_missing_data_var_attrs(xds):

--- a/src/xradio/measurement_set/_utils/_msv2/conversion.py
+++ b/src/xradio/measurement_set/_utils/_msv2/conversion.py
@@ -641,11 +641,9 @@ def create_data_variables(
             xds[datavar_name] = xr.DataArray(
                 col_data,
                 dims=col_dims[col],
+                attrs=create_attribute_metadata(col, main_column_descriptions)
             )
 
-            xds[datavar_name].attrs.update(
-                create_attribute_metadata(col, main_column_descriptions)
-            )
             logger.debug(
                 "Time to read column " + str(col) + " : " + str(time.time() - start)
             )

--- a/src/xradio/measurement_set/_utils/_msv2/conversion.py
+++ b/src/xradio/measurement_set/_utils/_msv2/conversion.py
@@ -612,12 +612,14 @@ def create_data_variables(
         col_names = tb_tool.colnames()
 
     valid_col_names = set(col_names) & set(col_to_data_variable_names.keys())
+    if valid_col_names.issuperset({"WEIGHT", "WEIGHT_SPECTRUM"}):
+        valid_col_names.remove("WEIGHT")
+
+    logger.debug(f"The following columns will be converted: {sorted(valid_col_names)}")
 
     main_table_attrs = extract_table_attributes(in_file)
     main_column_descriptions = main_table_attrs["column_descriptions"]
     for col in valid_col_names:
-        if (col == "WEIGHT") and ("WEIGHT_SPECTRUM" in valid_col_names):
-            continue
         try:
             start = time.time()
             if col == "WEIGHT":

--- a/src/xradio/measurement_set/_utils/_msv2/conversion.py
+++ b/src/xradio/measurement_set/_utils/_msv2/conversion.py
@@ -602,7 +602,6 @@ def create_data_variables(
     # Set read_col_conversion from value of `parallel_mode` argument
     # TODO: To make this compatible with multi-node conversion, `read_col_conversion_dask` and TableManager must be pickled.
     # Casacore will make this difficult
-    global read_col_conversion
     read_col_conversion = (
         read_col_conversion_dask if parallel_mode == "time"
         else read_col_conversion_numpy

--- a/src/xradio/measurement_set/_utils/_msv2/conversion.py
+++ b/src/xradio/measurement_set/_utils/_msv2/conversion.py
@@ -639,10 +639,8 @@ def create_data_variables(
                 dims=col_dims[col],
                 attrs=create_attribute_metadata(col, main_column_descriptions)
             )
+            logger.debug(f"Time to read column {col} : {time.time() - start}")
 
-            logger.debug(
-                "Time to read column " + str(col) + " : " + str(time.time() - start)
-            )
         except Exception as exc:
             logger.debug(f"Could not load column {col}, exception: {exc}")
             logger.debug(traceback.format_exc())

--- a/src/xradio/measurement_set/_utils/_msv2/conversion.py
+++ b/src/xradio/measurement_set/_utils/_msv2/conversion.py
@@ -615,8 +615,6 @@ def create_data_variables(
     if target_cols.issuperset({"WEIGHT", "WEIGHT_SPECTRUM"}):
         target_cols.remove("WEIGHT")
 
-    logger.debug(f"The following columns will be converted: {sorted(target_cols)}")
-
     main_table_attrs = extract_table_attributes(in_file)
     main_column_descriptions = main_table_attrs["column_descriptions"]
 

--- a/src/xradio/measurement_set/_utils/_msv2/conversion.py
+++ b/src/xradio/measurement_set/_utils/_msv2/conversion.py
@@ -631,7 +631,6 @@ def create_data_variables(
                     tidxs,
                     bidxs,
                     use_table_iter,
-                    main_column_descriptions,
                     time_chunksize,
                 )
             else:
@@ -655,7 +654,6 @@ def create_data_variables(
             xds[col_to_data_variable_names[col]].attrs.update(
                 create_attribute_metadata(col, main_column_descriptions)
             )
-
             logger.debug(
                 "Time to read column " + str(col) + " : " + str(time.time() - start)
             )
@@ -713,7 +711,6 @@ def get_weight(
     tidxs,
     bidxs,
     use_table_iter,
-    main_column_descriptions,
     time_chunksize,
 ):
     # da.tile() behaves differently to np.tile() so rechunking is necessary.

--- a/src/xradio/measurement_set/_utils/_msv2/conversion.py
+++ b/src/xradio/measurement_set/_utils/_msv2/conversion.py
@@ -652,16 +652,19 @@ def create_data_variables(
         except Exception as exc:
             logger.debug(f"Could not load column {col}, exception: {exc}")
             logger.debug(traceback.format_exc())
-            
-            # Bogus WEIGHT_SPECTRUM column, try falling back onto WEIGHT
-            if col == "WEIGHT_SPECTRUM" and "WEIGHT" in col_names:  
+
+            if col == "WEIGHT_SPECTRUM" and "WEIGHT" in col_names:
+                logger.debug(
+                    "Failed to convert WEIGHT_SPECTRUM column: "
+                    "will attempt to use WEIGHT instead"
+                )
                 target_cols.append("WEIGHT")
 
 
 def get_read_col_conversion_function(col_name: str, parallel_mode: str) -> Callable:
     """
-    Select the read_col_conversion function: use the dask version for large
-    columns and parallel_mode="time", or the numpy version otherwise.
+    Returns the appropriate read_col_conversion function: use the dask version
+    for large columns and parallel_mode="time", or the numpy version otherwise.
     """
     large_columns = {
         "DATA",

--- a/src/xradio/measurement_set/_utils/_msv2/conversion.py
+++ b/src/xradio/measurement_set/_utils/_msv2/conversion.py
@@ -733,10 +733,6 @@ def get_weight(
         ),
         dims=col_dims[col],
     ).chunk(chunks={"frequency": -1})
-
-    xds[col_to_data_variable_names[col]].attrs.update(
-        create_attribute_metadata(col, main_column_descriptions)
-    )
     return xds
 
 

--- a/src/xradio/measurement_set/_utils/_msv2/conversion.py
+++ b/src/xradio/measurement_set/_utils/_msv2/conversion.py
@@ -586,13 +586,12 @@ def create_data_variables(
     parallel_mode,
     main_chunksize,
 ):
-    if parallel_mode == "time" and "time" not in main_chunksize:
+    time_chunksize = main_chunksize.get("time", None) if main_chunksize else None
+    if parallel_mode == "time" and time_chunksize is None:
         logger.warning(
             "'time' isn't specified in `main_chunksize`. Defaulting to `parallel_mode = 'none'`."
         )
         parallel_mode = "none"
-
-    time_chunksize = main_chunksize.get("time", None)
 
     # Create Data Variables
     with table_manager.get_table() as tb_tool:

--- a/tests/stakeholder/test_measure_set_stakeholder.py
+++ b/tests/stakeholder/test_measure_set_stakeholder.py
@@ -31,7 +31,9 @@ def tmp_path():
     return pathlib.Path("/tmp/test")
 
 
-def download_and_convert_msv2_to_processing_set(msv2_name, folder, partition_scheme):
+def download_and_convert_msv2_to_processing_set(
+    msv2_name, folder, partition_scheme, parallel_mode: str = "none"
+):
 
     # We can remove this once there is a new release of casacore
     # if os.environ["USER"] == "runner":
@@ -77,7 +79,7 @@ def download_and_convert_msv2_to_processing_set(msv2_name, folder, partition_sch
         # sys_cal_interpolate=True,
         use_table_iter=False,
         overwrite=True,
-        parallel_mode="none",
+        parallel_mode=parallel_mode,
     )
     return ps_name
 
@@ -284,6 +286,7 @@ def base_test(
     expected_sum_value: float,
     is_s3: bool = False,
     partition_schemes: list = [[], ["FIELD_ID"]],
+    parallel_mode: str = "none",
     preconverted: bool = False,
     do_schema_check: bool = True,
     expected_secondary_xds: set = None,
@@ -306,7 +309,7 @@ def base_test(
             ps_name = file_name
         else:
             ps_name = download_and_convert_msv2_to_processing_set(
-                file_name, folder, partition_scheme
+                file_name, folder, partition_scheme, parallel_mode=parallel_mode
             )
 
         print(f"Opening Processing Set, {ps_name}")
@@ -427,6 +430,7 @@ def test_ska_low(tmp_path):
         tmp_path,
         119802044416.0,
         expected_secondary_xds=expected_subtables,
+        parallel_mode="time",
     )
 
 
@@ -437,6 +441,7 @@ def test_ska_mid(tmp_path):
         tmp_path,
         551412.3125,
         expected_secondary_xds=expected_subtables,
+        parallel_mode="time",
     )
 
 


### PR DESCRIPTION
New version of #423, because I could not rebase onto main / merge main into it without losing most of the code changes.

Credit goes to @sstansill for the original changes:
- Fixes a crash when converting a dataset without WEIGHT_SPECTRUM using `parallel_mode="time"`, where the chunking pattern in frequency would be incorrect.
- Use `dask.array.tile()` instead of `np.tile()` when using `parallel_mode="time"`. This ensures WEIGHT and WEIGHT_SPECTRUM columns aren't eagerly computed eagerly, reducing memory usage.
- Use `read_col_conversion_dask()` only on large columns, this improves performance.

I've refactored and simplified `create_date_variables()` along the way:
- Remove all-encompassing `if` statement inside main loop that was checking for the presence of WEIGHT + WEIGHT_SPECTRUM, moved that outside of the loop
- Streamlined logic in that order: read column into array, apply special treatment to some columns, then wrap the data into a DataArray.
- Replaced `get_weight()` by something simpler as a result
- In the `except` statement, better handling of the case where WEIGHT_SPECTRUM conversion fails. In the old version, if the fallback conversion of WEIGHT failed, we'd be raising an exception from inside the `except` statement, which was not the intention. Now, if need be, we just dynamically add WEIGHT to the queue of column names to convert. This also avoid code repetition.
