### PR TITLE
Make import of msv4 functions possible when python-casacore and casatools are not available

### DIFF
--- a/docs/sphinx.txt
+++ b/docs/sphinx.txt
@@ -25,4 +25,5 @@ scanpydoc==0.9.5
 twine==4.0.2
 pandoc==2.3
 myst-parser==4.0.1
-xradio
+xradio[python-casacore]
+

--- a/docs/sphinx.txt
+++ b/docs/sphinx.txt
@@ -25,5 +25,4 @@ scanpydoc==0.9.5
 twine==4.0.2
 pandoc==2.3
 myst-parser==4.0.1
-xradio[python-casacore]
-
+xradio

--- a/src/xradio/_utils/_casacore/casacore_from_casatools.py
+++ b/src/xradio/_utils/_casacore/casacore_from_casatools.py
@@ -18,7 +18,17 @@ from typing import Any, Dict, List, Sequence, Union
 # Configure casaconfig settings prior to casatools import
 # this ensures optimal initialization and resource allocation for casatools
 # Also see : https://casadocs.readthedocs.io/en/stable/api/casaconfig.html
-import casaconfig.config
+try:
+    import casaconfig.config
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        f"casaconfig.config cannot be found, probably because the package "
+        "casatools is not available. If you are here that is probably because "
+        "python-casacore is not available either. MSv2 related functionality "
+        "requires either python-casacore or casatools. Import failure details: "
+        f"{exc}"
+    )
+
 import numpy as np
 import toolviper.utils.logger as logger
 

--- a/src/xradio/measurement_set/__init__.py
+++ b/src/xradio/measurement_set/__init__.py
@@ -4,13 +4,11 @@ convert, and retrieve information from Processing Set and Measurement Sets nodes
 Processing Set DataTree
 """
 
+import toolviper.utils.logger as _logger
+
 from .processing_set_xdt import ProcessingSetXdt
 from .open_processing_set import open_processing_set
 from .load_processing_set import load_processing_set
-from .convert_msv2_to_processing_set import (
-    convert_msv2_to_processing_set,
-    estimate_conversion_memory_and_cores,
-)
 from .measurement_set_xdt import MeasurementSetXdt
 from .schema import SpectrumXds, VisibilityXds
 
@@ -19,8 +17,21 @@ __all__ = [
     "MeasurementSetXdt",
     "open_processing_set",
     "load_processing_set",
-    "convert_msv2_to_processing_set",
-    "estimate_conversion_memory_and_cores",
     "SpectrumXds",
     "VisibilityXds",
 ]
+
+try:
+    from .convert_msv2_to_processing_set import (
+        convert_msv2_to_processing_set,
+        estimate_conversion_memory_and_cores,
+    )
+except ModuleNotFoundError as exc:
+    _logger.warning(
+        "Could not import the function to convert from MSv2 to MSv4. "
+        f"That functionality will not be available. Details: {exc}"
+    )
+else:
+    __all__.extend(
+        ["convert_msv2_to_processing_set", "estimate_conversion_memory_and_cores"]
+    )

--- a/src/xradio/measurement_set/_utils/_msv2/msv4_sub_xdss.py
+++ b/src/xradio/measurement_set/_utils/_msv2/msv4_sub_xdss.py
@@ -16,8 +16,11 @@ from xradio._utils.schema import (
     column_description_casacore_to_msv4_measure,
     convert_generic_xds_to_xradio_schema,
 )
-from .subtables import subt_rename_ids
-from ._tables.read import (
+from xradio.measurement_set._utils._utils.interpolate import (
+    interpolate_to_time,
+)
+from xradio.measurement_set._utils._msv2.subtables import subt_rename_ids
+from xradio.measurement_set._utils._msv2._tables.read import (
     load_generic_table,
     make_taql_where_between_min_max,
     table_exists,
@@ -86,61 +89,6 @@ def rename_and_interpolate_to_time(
         renamed_time_xds = renamed_time_xds.drop_vars(time_initial_name)
 
     return renamed_time_xds
-
-
-def interpolate_to_time(
-    xds: xr.Dataset,
-    interp_time: Union[xr.DataArray, None],
-    message_prefix: str,
-    time_name: str = "time",
-) -> xr.Dataset:
-    """
-    Interpolate the time coordinate of the input xarray dataset to the
-    a data array. This can be used for example to interpolate a pointing_xds
-    to the time coord of the (main) MSv4, or similarly the ephemeris
-    data variables of a field_and_source_xds.
-
-    Uses interpolation method "linear", unless the source number of points is
-    1 in which case "nearest" is used, to avoid divide-by-zero issues.
-
-    Parameters:
-    ----------
-    xds : xr.Dataset
-        Xarray dataset to interpolate (presumably a pointing_xds or an xds of
-        ephemeris variables)
-    interp_time : Union[xr.DataArray, None]
-        Time axis to interpolate the dataset to (usually main MSv4 time)
-    message_prefix: str
-        A prefix for info/debug/etc. messages
-
-    Returns:
-    -------
-    interpolated_xds : xr.Dataset
-        xarray dataset with time axis interpolated to interp_time.
-    """
-    if interp_time is not None:
-        points_before = xds[time_name].size
-        if points_before > 1:
-            method = "linear"
-        else:
-            method = "nearest"
-        xds = xds.interp(
-            {time_name: interp_time.data}, method=method, assume_sorted=True
-        )
-        # scan_name sneaks in as a coordinate of the main time axis, drop it
-        if (
-            "type" in xds.attrs
-            and xds.attrs["type"] not in ["visibility", "spectrum", "wvr"]
-            and "scan_name" in xds.coords
-        ):
-            xds = xds.drop_vars("scan_name")
-        points_after = xds[time_name].size
-        logger.debug(
-            f"{message_prefix}: interpolating the time coordinate "
-            f"from {points_before} to {points_after} points"
-        )
-
-    return xds
 
 
 def make_taql_where_weather(

--- a/src/xradio/measurement_set/_utils/_utils/interpolate.py
+++ b/src/xradio/measurement_set/_utils/_utils/interpolate.py
@@ -1,0 +1,60 @@
+from typing import Union
+
+import xarray as xr
+
+import toolviper.utils.logger as logger
+
+
+def interpolate_to_time(
+    xds: xr.Dataset,
+    interp_time: Union[xr.DataArray, None],
+    message_prefix: str,
+    time_name: str = "time",
+) -> xr.Dataset:
+    """
+    Interpolate the time coordinate of the input xarray dataset to the
+    a data array. This can be used for example to interpolate a pointing_xds
+    to the time coord of the (main) MSv4, or similarly the ephemeris
+    data variables of a field_and_source_xds.
+
+    Uses interpolation method "linear", unless the source number of points is
+    1 in which case "nearest" is used, to avoid divide-by-zero issues.
+
+    Parameters:
+    ----------
+    xds : xr.Dataset
+        Xarray dataset to interpolate (presumably a pointing_xds or an xds of
+        ephemeris variables)
+    interp_time : Union[xr.DataArray, None]
+        Time axis to interpolate the dataset to (usually main MSv4 time)
+    message_prefix: str
+        A prefix for info/debug/etc. messages
+
+    Returns:
+    -------
+    interpolated_xds : xr.Dataset
+        xarray dataset with time axis interpolated to interp_time.
+    """
+    if interp_time is not None:
+        points_before = xds[time_name].size
+        if points_before > 1:
+            method = "linear"
+        else:
+            method = "nearest"
+        xds = xds.interp(
+            {time_name: interp_time.data}, method=method, assume_sorted=True
+        )
+        # scan_name sneaks in as a coordinate of the main time axis, drop it
+        if (
+            "type" in xds.attrs
+            and xds.attrs["type"] not in ["visibility", "spectrum", "wvr"]
+            and "scan_name" in xds.coords
+        ):
+            xds = xds.drop_vars("scan_name")
+        points_after = xds[time_name].size
+        logger.debug(
+            f"{message_prefix}: interpolating the time coordinate "
+            f"from {points_before} to {points_after} points"
+        )
+
+    return xds

--- a/src/xradio/measurement_set/processing_set_xdt.py
+++ b/src/xradio/measurement_set/processing_set_xdt.py
@@ -469,7 +469,7 @@ class ProcessingSetXdt:
                     del field_and_source_xds["line_name"]
                     del field_and_source_xds["line_label"]
 
-                from xradio.measurement_set._utils._msv2.msv4_sub_xdss import (
+                from xradio.measurement_set._utils._utils.interpolate import (
                     interpolate_to_time,
                 )
 

--- a/tests/unit/measurement_set/_utils/_msv2/test_msv4_sub_xdss.py
+++ b/tests/unit/measurement_set/_utils/_msv2/test_msv4_sub_xdss.py
@@ -55,27 +55,6 @@ def test_rename_and_interpoalte_to_time_main(msv4_xds_min):
     xr.testing.assert_equal(out_xds.time, input_time)
 
 
-def test_interpolate_to_time_bogus(antenna_xds_min, msv4_xds_min):
-    from xradio.measurement_set._utils._msv2.msv4_sub_xdss import interpolate_to_time
-
-    input_time = msv4_xds_min.time
-    out_xds = interpolate_to_time(
-        antenna_xds_min, interp_time=input_time, message_prefix="test_call"
-    )
-    assert out_xds == input_time
-
-
-def test_interpolate_to_time_main(msv4_xds_min):
-    from xradio.measurement_set._utils._msv2.msv4_sub_xdss import interpolate_to_time
-
-    input_time = msv4_xds_min.time
-    out_xds = interpolate_to_time(
-        msv4_xds_min, interp_time=input_time, message_prefix="test_call"
-    )
-
-    xr.testing.assert_equal(out_xds.time, input_time)
-
-
 @pytest.fixture(scope="session")
 def ant_xds_station_name_ids():
     """Makes a ant_xds_station_name_ids as the one used in conversion (it still has antenna_id coord)"""

--- a/tests/unit/measurement_set/_utils/_utils/test_interpolate.py
+++ b/tests/unit/measurement_set/_utils/_utils/test_interpolate.py
@@ -1,0 +1,24 @@
+import pytest
+
+import xarray as xr
+
+
+def test_interpolate_to_time_bogus(antenna_xds_min, msv4_xds_min):
+    from xradio.measurement_set._utils._utils.interpolate import interpolate_to_time
+
+    input_time = msv4_xds_min.time
+    out_xds = interpolate_to_time(
+        antenna_xds_min, interp_time=input_time, message_prefix="test_call"
+    )
+    assert out_xds == input_time
+
+
+def test_interpolate_to_time_main(msv4_xds_min):
+    from xradio.measurement_set._utils._utils.interpolate import interpolate_to_time
+
+    input_time = msv4_xds_min.time
+    out_xds = interpolate_to_time(
+        msv4_xds_min, interp_time=input_time, message_prefix="test_call"
+    )
+
+    xr.testing.assert_equal(out_xds.time, input_time)


### PR DESCRIPTION
Fixes #461, see issue for details.

casadocs seems to build fine: https://app.readthedocs.org/projects/xradio/builds/29133660/

Note that if we want to test all the alternatives we'd need yet another workflow/setup together with the jobs/tests that run using python-casacore and the jobs/tests that run with casatools.