### PR TITLE
Added image_type optional argument to read_image

### DIFF
--- a/src/xradio/image/image.py
+++ b/src/xradio/image/image.py
@@ -103,10 +103,15 @@ def read_image(
         not the software's, to ensure that the mask is computed if it is necessary. Currently only
         implemented for FITS images.
     image_type : str, optional
-        If None (default), the infile will attempt to be processed as a CASA, FITS, or zarr image. This is equivalent to image_type = 'casa fits zarr'.
-        If image_type contains the string 'CASA' (case independant), the infile will only attempt to be processed as a CASA image.
-        if image_type contains the string 'FITS' (case independant), the infile will only attempt to be processed as a FITS image.
-        if image_type contains the string 'zarr' (case independant), the infile will only attempt to be processed as a zarr image.
+        If None (default),
+            the infile will attempt to be processed as a CASA, FITS, or zarr image.
+            This is equivalent to image_type = 'casa fits zarr'.
+        If image_type contains the string 'CASA' (case independant),
+            the infile will only attempt to be processed as a CASA image.
+        if image_type contains the string 'FITS' (case independant),
+            the infile will only attempt to be processed as a FITS image.
+        if image_type contains the string 'zarr' (case independant),
+            the infile will only attempt to be processed as a zarr image.
     Returns
     -------
     xarray.Dataset

--- a/src/xradio/image/image.py
+++ b/src/xradio/image/image.py
@@ -144,7 +144,7 @@ def read_image(
             return _fits_image_to_xds(infile, chunks, verbose, do_sky_coords, compute_mask)
         except Exception as e:
             emsgs.append(f"image format appears not to be fits {e.args}")
-    if image_type is None or 'fits' in image_type.lower():
+    if image_type is None or 'zarr' in image_type.lower():
         # when done debuggin comment out next line
         # return _xds_from_zarr(infile, {"dv": "dask", "coords": "numpy"}, selection=selection)
         try:


### PR DESCRIPTION
Contributing requested enhancement for:
- https://github.com/casangi/xradio/issues/442

An optional parameter image_type : str has been added, defaulting to None, for each supported image type, image_type is checked for None and for containing a case insensitive string matching the supported image type.

https://github.com/casangi/xradio/blob/1221e20e22a01ea3f713d4a679281cdada7fa338/src/xradio/image/image.py#L105-L114