### PR TITLE
Remove typeguard dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     'xarray',
     'zarr>=2,<3',
     'pyarrow',
-    'typeguard',
     'numcodecs<0.16',
     'psutil' # psutil is needed so large FITS images are not loaded into memory
 ]


### PR DESCRIPTION
The remaining functionality the schema check needs can be easily implemented directly using "isinstance".

This should make `xarray` the only dependency of the schema checker.