### PR TITLE
Fix API documentation missing

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,7 +16,7 @@ python:
     - method: pip
       path: .
       extra_requirements:
-        - python-casacore
+        - casacore
 
 # Configuration for Sphinx documentation
 sphinx:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,6 +91,11 @@ napoleon_type_aliases = {
 
 nitpicky = True
 
+# Ignore nitpicky warnings related to Python built-ins and the like
+# (https://stackoverflow.com/questions/11417221/sphinx-autodoc-gives-warning-pyclass-reference-target-not-found-type-warning)
+# (https://bugs.python.org/issue11975)
+nitpick_ignore = [('py:class', 'optional')]
+
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "astropy": ("https://docs.astropy.org/en/stable", None),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,7 +94,7 @@ nitpicky = True
 # Ignore nitpicky warnings related to Python built-ins and the like
 # (https://stackoverflow.com/questions/11417221/sphinx-autodoc-gives-warning-pyclass-reference-target-not-found-type-warning)
 # (https://bugs.python.org/issue11975)
-nitpick_ignore = [('py:class', 'optional')]
+nitpick_ignore = [("py:class", "optional")]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),


### PR DESCRIPTION
Fixes #559. This brings back `convert_msv2_to_processing_set` and `estimate_conversion_memory_and_cores`.