### PR TITLE
Make XRadIO notebooks work in colab (or any other environment where dependencies are not pre-installed)

### DIFF
--- a/docs/source/measurement_set/guides/ALMA_SD.ipynb
+++ b/docs/source/measurement_set/guides/ALMA_SD.ipynb
@@ -32,7 +32,7 @@
     "    print(e)\n",
     "    print(\"Installing XRADIO\")\n",
     "\n",
-    "    os.system(\"pip install xradio\")\n",
+    "    os.system(\"pip install xradio[all]\")\n",
     "\n",
     "    import xradio\n",
     "\n",
@@ -6258,7 +6258,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/source/measurement_set/guides/ALMA_ephemeris.ipynb
+++ b/docs/source/measurement_set/guides/ALMA_ephemeris.ipynb
@@ -34,7 +34,7 @@
     "    print(e)\n",
     "    print(\"Installing XRADIO\")\n",
     "\n",
-    "    os.system(\"pip install xradio\")\n",
+    "    os.system(\"pip install xradio[all]\")\n",
     "\n",
     "    import xradio\n",
     "\n",
@@ -6036,7 +6036,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/source/measurement_set/guides/GBT_single_dish.ipynb
+++ b/docs/source/measurement_set/guides/GBT_single_dish.ipynb
@@ -34,7 +34,7 @@
     "    print(e)\n",
     "    print(\"Installing XRADIO\")\n",
     "\n",
-    "    os.system(\"pip install xradio\")\n",
+    "    os.system(\"pip install xradio[all]\")\n",
     "\n",
     "    import xradio\n",
     "\n",
@@ -5130,7 +5130,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "timg",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/source/measurement_set/guides/GMRT.ipynb
+++ b/docs/source/measurement_set/guides/GMRT.ipynb
@@ -34,7 +34,7 @@
     "    print(f\"Could not import XRADIO: {exc}\")\n",
     "    print(\"Installing XRADIO\")\n",
     "\n",
-    "    os.system(\"pip install xradio\")\n",
+    "    os.system(\"pip install xradio[all]\")\n",
     "\n",
     "    import xradio\n",
     "\n",
@@ -4495,7 +4495,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/source/measurement_set/guides/LOFAR.ipynb
+++ b/docs/source/measurement_set/guides/LOFAR.ipynb
@@ -34,7 +34,7 @@
     "    print(e)\n",
     "    print(\"Installing XRADIO\")\n",
     "\n",
-    "    os.system(\"pip install xradio\")\n",
+    "    os.system(\"pip install xradio[all]\")\n",
     "\n",
     "    import xradio\n",
     "\n",
@@ -4183,7 +4183,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/source/measurement_set/guides/MeerKAT.ipynb
+++ b/docs/source/measurement_set/guides/MeerKAT.ipynb
@@ -34,7 +34,7 @@
     "    print(e)\n",
     "    print(\"Installing XRADIO\")\n",
     "\n",
-    "    os.system(\"pip install xradio\")\n",
+    "    os.system(\"pip install xradio[all]\")\n",
     "\n",
     "    import xradio\n",
     "\n",
@@ -3745,7 +3745,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/source/measurement_set/guides/SKA_low.ipynb
+++ b/docs/source/measurement_set/guides/SKA_low.ipynb
@@ -32,7 +32,7 @@
     "    print(e)\n",
     "    print(\"Installing XRADIO\")\n",
     "\n",
-    "    os.system(\"pip install xradio\")\n",
+    "    os.system(\"pip install xradio[all]\")\n",
     "\n",
     "    import xradio\n",
     "\n",
@@ -4055,7 +4055,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/source/measurement_set/guides/SKA_mid.ipynb
+++ b/docs/source/measurement_set/guides/SKA_mid.ipynb
@@ -34,7 +34,7 @@
     "    print(e)\n",
     "    print(\"Installing XRADIO\")\n",
     "\n",
-    "    os.system(\"pip install xradio\")\n",
+    "    os.system(\"pip install xradio[all]\")\n",
     "\n",
     "    import xradio\n",
     "\n",
@@ -4209,7 +4209,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/source/measurement_set/guides/VLBA.ipynb
+++ b/docs/source/measurement_set/guides/VLBA.ipynb
@@ -34,7 +34,7 @@
     "    print(e)\n",
     "    print(\"Installing XRADIO\")\n",
     "\n",
-    "    os.system(\"pip install xradio\")\n",
+    "    os.system(\"pip install xradio[all]\")\n",
     "\n",
     "    import xradio\n",
     "\n",
@@ -11379,7 +11379,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/source/measurement_set/guides/VLBI.ipynb
+++ b/docs/source/measurement_set/guides/VLBI.ipynb
@@ -34,7 +34,7 @@
     "    print(e)\n",
     "    print(\"Installing XRADIO\")\n",
     "\n",
-    "    os.system(\"pip install xradio\")\n",
+    "    os.system(\"pip install xradio[all]\")\n",
     "\n",
     "    import xradio\n",
     "\n",
@@ -6001,7 +6001,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/source/measurement_set/guides/multi_msv2_conv.ipynb
+++ b/docs/source/measurement_set/guides/multi_msv2_conv.ipynb
@@ -12,6 +12,31 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "29879bfb-8269-47aa-a849-0e4a4579803a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from importlib.metadata import version\n",
+    "import os\n",
+    "\n",
+    "try:\n",
+    "    import xradio\n",
+    "\n",
+    "    print(\"XRADIO version\", version(\"xradio\"), \"already installed.\")\n",
+    "except ImportError as e:\n",
+    "    print(e)\n",
+    "    print(\"Installing XRADIO\")\n",
+    "\n",
+    "    os.system(\"pip install xradio[all]\")\n",
+    "\n",
+    "    import xradio\n",
+    "\n",
+    "    print(\"xradio version\", version(\"xradio\"), \" installed.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "id": "263aa226",
    "metadata": {},
@@ -313,7 +338,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "timg",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/source/measurement_set/guides/ngEHT.ipynb
+++ b/docs/source/measurement_set/guides/ngEHT.ipynb
@@ -34,7 +34,7 @@
     "    print(e)\n",
     "    print(\"Installing XRADIO\")\n",
     "\n",
-    "    os.system(\"pip install xradio\")\n",
+    "    os.system(\"pip install xradio[all]\")\n",
     "\n",
     "    import xradio\n",
     "\n",
@@ -3239,7 +3239,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/source/measurement_set/tutorials/measurement_set_tutorial.ipynb
+++ b/docs/source/measurement_set/tutorials/measurement_set_tutorial.ipynb
@@ -180,7 +180,7 @@
     "import os\n",
     "\n",
     "try:\n",
-    "    os.system(\"pip install --upgrade xradio\")\n",
+    "    os.system(\"pip install --upgrade xradio[all]\")\n",
     "\n",
     "    import xradio\n",
     "\n",
@@ -22252,7 +22252,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
This is a partial fix for https://github.com/casangi/RADPS-roadmap/issues/185 (in XRADIO, this repo, other fixes are needed in astroviper, etc.)

The approach is to add to the notebooks the `[all]` in `pip install xradio[all]` wherever needed, as done in the GitHub CI jobs (run-ipynb-template.yml).

